### PR TITLE
chore(meta): rename repository name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+on: [push, pull_request]
+env:
+  CI: true
+jobs:
+  test:
+    name: "Test on Node.js ${{ matrix.node_version }} OS: ${{matrix.os}}"
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-18.04]
+        node_version: [10, 12]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: setup Node ${{ matrix.node_version }}
+        uses: actions/setup-node@v1
+        with:
+          node_version: ${{ matrix.node_version }}
+      - name: Install
+        run: yarn install
+      - name: Test
+        run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ env:
   CI: true
 jobs:
   test:
-    name: "Test on Node.js ${{ matrix.node_version }} OS: ${{matrix.os}}"
+    name: "Test on Node.js ${{ matrix.node_version }}"
     runs-on: ubuntu-18.04
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
         node_version: [10, 12]
     steps:
       - name: checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-sudo: false
-language: node_js
-node_js: stable

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# textlint-rule-spacing [![Build Status](https://travis-ci.org/textlint-ja/textlint-rule-spacing.svg?branch=master)](https://travis-ci.org/textlint-ja/textlint-rule-spacing)
+# textlint-rule-preset-ja-spacing [![Build Status](https://travis-ci.org/textlint-ja/textlint-rule-preset-ja-spacing.svg?branch=master)](https://travis-ci.org/textlint-ja/textlint-rule-preset-ja-spacing)
 
 [textlint](https://textlint.github.io/)のスペース関連のmonorepoです。
 
@@ -90,7 +90,7 @@ textlint --preset preset-ja-spacing README.md
 }
 ```
 
-またデフォルトでは、[textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-spacing/tree/master/packages/textlint-rule-ja-space-around-code)は無効になっています。
+またデフォルトでは、[textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code)は無効になっています。
 
 次のように設定することで、プリセットに含まれるすべてのルールを有効にできます。
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# textlint-rule-preset-ja-spacing [![Build Status](https://travis-ci.org/textlint-ja/textlint-rule-preset-ja-spacing.svg?branch=master)](https://travis-ci.org/textlint-ja/textlint-rule-preset-ja-spacing)
+# textlint-rule-preset-ja-spacing [![Actions Status](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/workflows/test/badge.svg)](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/actions?query=workflow%3A"test")
 
 [textlint](https://textlint.github.io/)のスペース関連のmonorepoです。
 

--- a/packages/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/README.md
+++ b/packages/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/README.md
@@ -33,7 +33,7 @@ textlint --rule ja-nakaguro-or-halfwidth-space-between-katakana README.md
 
 ## Changelog
 
-See [Releases page](https://github.com/textlint-ja/textlint-rule-spacing/releases).
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
 
 ## Running tests
 
@@ -45,7 +45,7 @@ Install devDependencies and Run `npm test`:
 
 Pull requests and stars are always welcome.
 
-For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-spacing/issues).
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`

--- a/packages/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/package.json
+++ b/packages/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/package.json
@@ -9,14 +9,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textlint-ja/textlint-rule-spacing.git"
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/textlint-ja/textlint-rule-spacing",
+  "homepage": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/textlint-ja/textlint-rule-spacing/issues"
+    "url": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues"
   },
   "scripts": {
     "build": "NODE_ENV=production babel src --out-dir lib --source-maps",

--- a/packages/textlint-rule-ja-no-space-around-parentheses/README.md
+++ b/packages/textlint-rule-ja-no-space-around-parentheses/README.md
@@ -43,7 +43,7 @@ textlint --rule ja-no-space-around-parentheses README.md
 
 ## Changelog
 
-See [Releases page](https://github.com/extlint-ja/textlint-rule-spacing/releases).
+See [Releases page](https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/releases).
 
 ## Running tests
 
@@ -55,7 +55,7 @@ Install devDependencies and Run `npm test`:
 
 Pull requests and stars are always welcome.
 
-For bugs and feature requests, [please create an issue](https://github.com/extlint-ja/textlint-rule-spacing/issues).
+For bugs and feature requests, [please create an issue](https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/issues).
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`

--- a/packages/textlint-rule-ja-no-space-around-parentheses/package.json
+++ b/packages/textlint-rule-ja-no-space-around-parentheses/package.json
@@ -9,14 +9,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textlint-ja/textlint-rule-spacing.git"
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/extlint-ja/textlint-rule-spacing",
+  "homepage": "https://github.com/extlint-ja/textlint-rule-preset-ja-spacing",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/extlint-ja/textlint-rule-spacing/issues"
+    "url": "https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/issues"
   },
   "scripts": {
     "build": "NODE_ENV=production babel src --out-dir lib --source-maps",

--- a/packages/textlint-rule-ja-no-space-between-full-width/README.md
+++ b/packages/textlint-rule-ja-no-space-between-full-width/README.md
@@ -40,7 +40,7 @@ textlint --rule ja-no-space-between-full-width README.md
 
 ## Changelog
 
-See [Releases page](https://github.com/textlint-ja/textlint-rule-spacing/releases).
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
 
 ## Running tests
 
@@ -52,7 +52,7 @@ Install devDependencies and Run `npm test`:
 
 Pull requests and stars are always welcome.
 
-For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-spacing/issues).
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`

--- a/packages/textlint-rule-ja-no-space-between-full-width/package.json
+++ b/packages/textlint-rule-ja-no-space-between-full-width/package.json
@@ -9,14 +9,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textlint-ja/textlint-rule-spacing.git"
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/textlint-ja/textlint-rule-spacing",
+  "homepage": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/textlint-ja/textlint-rule-spacing/issues"
+    "url": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues"
   },
   "scripts": {
     "build": "NODE_ENV=production babel src --out-dir lib --source-maps",

--- a/packages/textlint-rule-ja-space-after-exclamation/README.md
+++ b/packages/textlint-rule-ja-space-after-exclamation/README.md
@@ -40,7 +40,7 @@ textlint --rule ja-space-after-exclamation README.md
 
 ## Changelog
 
-See [Releases page](https://github.com/extlint-ja/textlint-rule-spacing/releases).
+See [Releases page](https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/releases).
 
 ## Running tests
 
@@ -52,7 +52,7 @@ Install devDependencies and Run `npm test`:
 
 Pull requests and stars are always welcome.
 
-For bugs and feature requests, [please create an issue](https://github.com/extlint-ja/textlint-rule-spacing/issues).
+For bugs and feature requests, [please create an issue](https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/issues).
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`

--- a/packages/textlint-rule-ja-space-after-exclamation/package.json
+++ b/packages/textlint-rule-ja-space-after-exclamation/package.json
@@ -9,14 +9,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textlint-ja/textlint-rule-spacing.git"
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/extlint-ja/textlint-rule-spacing",
+  "homepage": "https://github.com/extlint-ja/textlint-rule-preset-ja-spacing",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/extlint-ja/textlint-rule-spacing/issues"
+    "url": "https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/issues"
   },
   "scripts": {
     "build": "NODE_ENV=production babel src --out-dir lib --source-maps",

--- a/packages/textlint-rule-ja-space-after-question/README.md
+++ b/packages/textlint-rule-ja-space-after-question/README.md
@@ -43,7 +43,7 @@ textlint --rule ja-space-after-question README.md
 
 ## Changelog
 
-See [Releases page](https://github.com/extlint-ja/textlint-rule-spacing/releases).
+See [Releases page](https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/releases).
 
 ## Running tests
 
@@ -55,7 +55,7 @@ Install devDependencies and Run `npm test`:
 
 Pull requests and stars are always welcome.
 
-For bugs and feature requests, [please create an issue](https://github.com/extlint-ja/textlint-rule-spacing/issues).
+For bugs and feature requests, [please create an issue](https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/issues).
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`

--- a/packages/textlint-rule-ja-space-after-question/package.json
+++ b/packages/textlint-rule-ja-space-after-question/package.json
@@ -9,14 +9,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textlint-ja/textlint-rule-spacing.git"
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/extlint-ja/textlint-rule-spacing",
+  "homepage": "https://github.com/extlint-ja/textlint-rule-preset-ja-spacing",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/extlint-ja/textlint-rule-spacing/issues"
+    "url": "https://github.com/extlint-ja/textlint-rule-preset-ja-spacing/issues"
   },
   "scripts": {
     "build": "NODE_ENV=production babel src --out-dir lib --source-maps",

--- a/packages/textlint-rule-ja-space-around-code/README.md
+++ b/packages/textlint-rule-ja-space-around-code/README.md
@@ -65,7 +65,7 @@ textlint --rule ja-space-around-code README.md
 
 ## Changelog
 
-See [Releases page](https://github.com/textlint-ja/textlint-rule-spacing/releases).
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
 
 ## Running tests
 
@@ -77,7 +77,7 @@ Install devDependencies and Run `npm test`:
 
 Pull requests and stars are always welcome.
 
-For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-spacing/issues).
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`

--- a/packages/textlint-rule-ja-space-around-code/package.json
+++ b/packages/textlint-rule-ja-space-around-code/package.json
@@ -9,14 +9,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textlint-ja/textlint-rule-spacing.git"
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/textlint-ja/textlint-rule-spacing",
+  "homepage": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/textlint-ja/textlint-rule-spacing/issues"
+    "url": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues"
   },
   "scripts": {
     "build": "NODE_ENV=production babel src --out-dir lib --source-maps",

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
@@ -80,7 +80,7 @@ textlint --rule ja-space-between-half-and-full-width README.md
 
 ## Changelog
 
-See [Releases page](https://github.com/textlint-ja/textlint-rule-spacing/releases).
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
 
 ## Running tests
 
@@ -92,7 +92,7 @@ Install devDependencies and Run `npm test`:
 
 Pull requests and stars are always welcome.
 
-For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-spacing/issues).
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/package.json
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/package.json
@@ -9,14 +9,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textlint-ja/textlint-rule-spacing.git"
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/textlint-ja/textlint-rule-spacing",
+  "homepage": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/textlint-ja/textlint-rule-spacing/issues"
+    "url": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues"
   },
   "scripts": {
     "build": "NODE_ENV=production babel src --out-dir lib --source-maps",

--- a/packages/textlint-rule-preset-ja-spacing/README.md
+++ b/packages/textlint-rule-preset-ja-spacing/README.md
@@ -5,7 +5,7 @@
 
 含まれているルールに関しては以下を参照してください。
 
-- [textlint-ja/textlint-rule-spacing: スペース周りのスタイルを扱うtextlintルール集](https://github.com/textlint-ja/textlint-rule-spacing "textlint-ja/textlint-rule-spacing: スペース周りのスタイルを扱うtextlintルール集")
+- [textlint-ja/textlint-rule-preset-ja-spacing: スペース周りのスタイルを扱うtextlintルール集](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing "textlint-ja/textlint-rule-preset-ja-spacing: スペース周りのスタイルを扱うtextlintルール集")
 
 それぞれのルールは個別のモジュールであるため、必要なルールのみをインストールすることも可能です。
 
@@ -36,7 +36,7 @@ textlint --preset ja-spacing README.md
 
 ## Options
 
-デフォルトでは、[textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-spacing/tree/master/packages/textlint-rule-ja-space-around-code)は無効になっています。
+デフォルトでは、[textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code)は無効になっています。
 
 次のように設定することで、プリセットに含まれるすべてのルールを有効にできます。
 
@@ -55,7 +55,7 @@ textlint --preset ja-spacing README.md
 
 ## Changelog
 
-See [Releases page](https://github.com/textlint-ja/textlint-rule-spacing/releases).
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
 
 ## Running tests
 
@@ -67,7 +67,7 @@ Install devDependencies and Run `npm test`:
 
 Pull requests and stars are always welcome.
 
-For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-spacing/issues).
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`

--- a/packages/textlint-rule-preset-ja-spacing/package.json
+++ b/packages/textlint-rule-preset-ja-spacing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "textlint-rule-preset-ja-spacing",
   "version": "2.0.1",
-  "description": "textlint-rule-spacingのルールプリセット",
+  "description": "textlint-rule-preset-ja-spacingのルールプリセット",
   "main": "lib/index.js",
   "files": [
     "src/",
@@ -9,14 +9,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/textlint-ja/textlint-rule-spacing.git"
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
   },
   "author": "azu",
   "email": "azuciao@gmail.com",
-  "homepage": "https://github.com/textlint-ja/textlint-rule-spacing",
+  "homepage": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/textlint-ja/textlint-rule-spacing/issues"
+    "url": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues"
   },
   "scripts": {
     "build": "NODE_ENV=production babel src --out-dir lib --source-maps",


### PR DESCRIPTION
`textlint-rule-spacing` to `textlint-rule-preset-ja-spacing`

fix #14 