### PR TITLE
fix: support LinkReference types

### DIFF
--- a/packages/textlint-rule-ja-no-space-around-parentheses/src/index.js
+++ b/packages/textlint-rule-ja-no-space-around-parentheses/src/index.js
@@ -26,7 +26,6 @@ function reporter(context) {
                 return;
             }
             const text = getSource(node);
-            console.log(text)
             // 左にスペース
             leftBrackets.forEach(pattern => {
                 matchCaptureGroupAll(text, pattern).forEach(match => {

--- a/packages/textlint-rule-ja-no-space-around-parentheses/src/index.js
+++ b/packages/textlint-rule-ja-no-space-around-parentheses/src/index.js
@@ -22,10 +22,11 @@ function reporter(context) {
     const helper = new RuleHelper();
     return {
         [Syntax.Str](node){
-            if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
+            if (helper.isChildNode(node, [Syntax.Link, "LinkReference", Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
                 return;
             }
             const text = getSource(node);
+            console.log(text)
             // 左にスペース
             leftBrackets.forEach(pattern => {
                 matchCaptureGroupAll(text, pattern).forEach(match => {

--- a/packages/textlint-rule-ja-no-space-around-parentheses/test/index-test.js
+++ b/packages/textlint-rule-ja-no-space-around-parentheses/test/index-test.js
@@ -12,7 +12,11 @@ tester.run("かっこ類と隣接する文字の間のスペースの有無", ru
 そのため、特別な実装は必要なく
 「拡張する時は\`calculator.prototype\`の代わりに\`calculator.fn\`を拡張してください」
 というルールがあるだけとも言えます。
-`
+`,
+        "[テスト 「文章」 です](https://example)", // ignore Link
+        "[テスト 「文章」 です][]" +
+        "\n\n" +
+        "[テスト 「文章」 です]: https://example.com" // ignore ReferenceDef
     ],
     invalid: [
         {

--- a/packages/textlint-rule-ja-no-space-between-full-width/src/index.js
+++ b/packages/textlint-rule-ja-no-space-between-full-width/src/index.js
@@ -16,7 +16,7 @@ function reporter(context) {
     const helper = new RuleHelper();
     return {
         [Syntax.Str](node){
-            if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
+            if (helper.isChildNode(node, [Syntax.Link, "LinkReference", Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
                 return;
             }
             const text = getSource(node);

--- a/packages/textlint-rule-ja-space-after-exclamation/src/index.js
+++ b/packages/textlint-rule-ja-space-after-exclamation/src/index.js
@@ -12,7 +12,7 @@ function reporter(context) {
     const helper = new RuleHelper();
     return {
         [Syntax.Str](node){
-            if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
+            if (helper.isChildNode(node, [Syntax.Link, "LinkReference", Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
                 return;
             }
             let text = getSource(node);

--- a/packages/textlint-rule-ja-space-after-question/src/index.js
+++ b/packages/textlint-rule-ja-space-after-question/src/index.js
@@ -12,7 +12,7 @@ function reporter(context) {
     const helper = new RuleHelper();
     return {
         [Syntax.Str](node){
-            if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
+            if (helper.isChildNode(node, [Syntax.Link, "LinkReference", Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
                 return;
             }
             let text = getSource(node);

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
@@ -77,7 +77,7 @@ function reporter(context, options = {}) {
     return {
         [Syntax.Str](node){
             const isIgnoredParentNode = helper.isChildNode(node, [
-                Syntax.Header, Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis
+                Syntax.Header, Syntax.Link, "LinkReference", Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis
             ]);
             if (isIgnoredParentNode) {
                 return;


### PR DESCRIPTION
```markdown
[title][id]
[title]

[title]: https://example.com
[id]: https://example.com
```

形式を判定しないように修正。

textlint側に `LinkReference` が定義されていない。。
https://github.com/textlint/textlint/issues/694