### PR TITLE
JTF日本語標準スタイルガイド（翻訳用）URLを修正しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ textlint --preset preset-ja-spacing README.md
 JTFスタイルガイドに含まれているルールと大部分は共通しています。
 以下のプリセットを利用している場合は重複するルールがあります。
 
-- [JTF日本語標準スタイルガイド（翻訳用）](https://www.jtf.jp/jp/style_guide/styleguide_top.html "JTF日本語標準スタイルガイド（翻訳用）")
+- [JTF日本語標準スタイルガイド（翻訳用）](https://www.jtf.jp/tips/styleguide "JTF日本語標準スタイルガイド（翻訳用）")
 - [azu/textlint-rule-preset-JTF-style: JTF日本語標準スタイルガイド for textlint.](https://github.com/azu/textlint-rule-preset-JTF-style "azu/textlint-rule-preset-JTF-style: JTF日本語標準スタイルガイド for textlint.")
 
 ## 開発フロー


### PR DESCRIPTION
## WHAT

[README](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing#%E9%96%A2%E9%80%A3)のJTF日本語標準スタイルガイド（翻訳用） URLが404だったので、修正しました。