### PR TITLE
feat(rule): add textlint-rule-ja-space-around-link

### DIFF
--- a/packages/textlint-rule-ja-space-around-link/CHANGELOG.md
+++ b/packages/textlint-rule-ja-space-around-link/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [2.0.2](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/compare/v2.0.1...v2.0.2) (2020-09-09)
+
+**Note:** Version bump only for package textlint-rule-ja-space-around-code

--- a/packages/textlint-rule-ja-space-around-link/README.md
+++ b/packages/textlint-rule-ja-space-around-link/README.md
@@ -1,0 +1,94 @@
+# textlint-rule-ja-space-around-link [![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+
+リンクの周りをスペースで囲むかどうかを決めるtextlintルール
+
+リンクとは[TxtAST](https://github.com/textlint/textlint/blob/master/docs/txtnode.md "TxtAST")の`Link` nodeのことです。
+
+このルールでは、リンクの前後が日本語である場合に半角スペースを入れるかを決定します。
+オプションでスペースの有無を決定できます。
+
+    [README](README.md) と日本語の間はスペースを空ける
+    [README](README.md)と日本語の間はスペースを空けない
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install textlint-rule-ja-space-around-link
+
+## Usage
+
+Via `.textlintrc`(Recommended)
+
+```json
+{
+    "rules": {
+        "ja-space-around-link": true
+    }
+}
+```
+
+Via CLI
+
+```
+textlint --rule ja-space-around-link README.md
+```
+
+
+## Options
+
+- `before`: `boolean`
+    - デフォルト: `false`
+    - `true`なら、`Link`の前に半角スペースを入れる
+- `after`: `boolean`
+    - デフォルト: `false`
+    - `true`なら、`Link`の後に半角スペースを入れる
+
+デフォルト値は次のようになります。
+
+```json
+{
+    "rules": {
+        "ja-space-around-link": {
+            "before": false,
+            "after": false
+        }
+    }
+}
+```
+
+## Fixable
+
+[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+
+`textlint --fix`の自動修正に対応しています。
+
+## Changelog
+
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm i -d && npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/0x6b](https://github.com/0x6b)
+
+## License
+
+MIT © 0x6b

--- a/packages/textlint-rule-ja-space-around-link/package.json
+++ b/packages/textlint-rule-ja-space-around-link/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "textlint-rule-ja-space-around-link",
+  "version": "2.0.2",
+  "description": "リンクの周りをスペースで囲むかどうかを決めるtextlintルール",
+  "main": "lib/index.js",
+  "files": [
+    "src/",
+    "lib/"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/textlint-ja/textlint-rule-preset-ja-spacing.git"
+  },
+  "author": "0x6b",
+  "homepage": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues"
+  },
+  "scripts": {
+    "build": "textlint-scripts build",
+    "watch": "textlint-scripts build --watch",
+    "prepublish": "npm run --if-present build",
+    "test": "textlint-scripts test"
+  },
+  "keywords": [
+    "textlint",
+    "textlintrule"
+  ],
+  "devDependencies": {
+    "textlint-scripts": "^3.0.0"
+  },
+  "dependencies": {
+    "match-index": "^1.0.1",
+    "textlint-rule-helper": "^2.0.0"
+  }
+}

--- a/packages/textlint-rule-ja-space-around-link/src/index.js
+++ b/packages/textlint-rule-ja-space-around-link/src/index.js
@@ -1,0 +1,90 @@
+// LICENSE : MIT
+"use strict";
+const isJapaneseChar = (text) => {
+  return /^(?:[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]|[ぁ-んァ-ヶ])$/.test(
+    text
+  );
+};
+const defaultOptions = {
+  before: false,
+  after: false,
+};
+function reporter(context, options) {
+  const { Syntax, RuleError, report, fixer, getSource } = context;
+  const allowBeforeSpace = options.before || defaultOptions.before;
+  const allowAfterSpace = options.after || defaultOptions.after;
+  return {
+    [Syntax.Link](node) {
+      const nodeText = getSource(node);
+      // |  `code`  |
+      // InlineCodeの前後2文字文を取得
+      // スペース + 前後の文字を取るため
+      // 文字が日本語以外はチェック対象にしないようにするため
+      const textWithPadding = getSource(node, 2, 2);
+      if (!textWithPadding) {
+        return;
+      }
+      const beforeChar = textWithPadding[1];
+      const beforeBeforeChar = textWithPadding[0];
+      const existBeforeChar = nodeText[0] !== beforeChar;
+      const afterChar = textWithPadding[textWithPadding.length - 2];
+      const afterAfterChar = textWithPadding[textWithPadding.length - 1];
+      const existAfterChar = nodeText[textWithPadding.length - 1] !== afterChar;
+      // InlineCodeの前に文字が存在している時のみチェック
+      if (existBeforeChar) {
+        if (allowBeforeSpace) {
+          if (beforeChar !== " " && isJapaneseChar(beforeChar)) {
+            report(
+              node,
+              new RuleError("リンクの前にスペースを入れてください。", {
+                index: -1, // before `
+                fix: fixer.insertTextBeforeRange([0, 0], " "),
+              })
+            );
+          }
+        } else {
+          if (beforeChar === " " && isJapaneseChar(beforeBeforeChar)) {
+            report(
+              node,
+              new RuleError("リンクの前にスペースを入れません。", {
+                index: -1, // before `
+                fix: fixer.replaceTextRange([-1, 0], ""),
+              })
+            );
+          }
+        }
+      }
+      // InlineCodeの後に文字が存在している時のみチェック
+      if (existAfterChar) {
+        if (allowAfterSpace) {
+          if (afterChar !== " " && isJapaneseChar(beforeChar)) {
+            report(
+              node,
+              new RuleError("リンクの後にスペースを入れてください。", {
+                index: nodeText.length,
+                fix: fixer.insertTextAfterRange([0, nodeText.length], " "),
+              })
+            );
+          }
+        } else {
+          if (afterChar === " " && isJapaneseChar(afterAfterChar)) {
+            report(
+              node,
+              new RuleError("リンクの後にスペースを入れません。", {
+                index: nodeText.length + 1,
+                fix: fixer.replaceTextRange(
+                  [nodeText.length, nodeText.length + 1],
+                  ""
+                ),
+              })
+            );
+          }
+        }
+      }
+    },
+  };
+}
+module.exports = {
+  linter: reporter,
+  fixer: reporter,
+};

--- a/packages/textlint-rule-ja-space-around-link/test/index-test.js
+++ b/packages/textlint-rule-ja-space-around-link/test/index-test.js
@@ -1,0 +1,141 @@
+// LICENSE : MIT
+"use strict";
+import TextLintTester from "textlint-tester";
+import rule from "../src/index";
+
+var tester = new TextLintTester();
+tester.run("Link周りのスペース", rule, {
+  valid: [
+    {
+      text: "[README](./README.md) と日本語の間はスペースを空ける",
+      options: {
+        before: true,
+        after: true,
+      },
+    },
+    {
+      text: "[README](./README.md)と日本語の間はスペースを空けない",
+      options: {
+        before: false,
+        after: false,
+      },
+    },
+    {
+      text: "[README](./README.md) is good in english text.",
+      options: {
+        before: false,
+        after: false,
+      },
+    },
+    {
+      text: "[`README`](./README.md) と日本語の間はスペースを空ける",
+      options: {
+        before: true,
+        after: true,
+      },
+    },
+    {
+      text: "[`README`](./README.md)と日本語の間はスペースを空けない",
+      options: {
+        before: false,
+        after: false,
+      },
+    },
+    {
+      text: "[`README`](./README.md) is good in english text.",
+      options: {
+        before: false,
+        after: false,
+      },
+    },
+    {
+      text: "[**README**](./README.md) と日本語の間はスペースを空ける",
+      options: {
+        before: true,
+        after: true,
+      },
+    },
+    {
+      text: "[**README**](./README.md)と日本語の間はスペースを空けない",
+      options: {
+        before: false,
+        after: false,
+      },
+    },
+    {
+      text: "[**README**](./README.md) is good in english text.",
+      options: {
+        before: false,
+        after: false,
+      },
+    },
+  ],
+  invalid: [
+    // before only
+    {
+      text: "これは [README](./README.md) おかしい",
+      output: "これは [README](./README.md)おかしい",
+      options: {
+        before: true,
+        after: false,
+      },
+      errors: [
+        {
+          message: "リンクの後にスペースを入れません。",
+          column: 27,
+        },
+      ],
+    },
+    // after only
+    {
+      text: "これは [README](./README.md) おかしい",
+      output: "これは[README](./README.md) おかしい",
+      options: {
+        before: false,
+        after: true,
+      },
+      errors: [
+        {
+          message: "リンクの前にスペースを入れません。",
+          column: 4,
+        },
+      ],
+    },
+    {
+      text: "これは [README](./README.md) おかしい",
+      output: "これは[README](./README.md)おかしい",
+      options: {
+        before: false,
+        after: false,
+      },
+      errors: [
+        {
+          message: "リンクの前にスペースを入れません。",
+          column: 4,
+        },
+        {
+          message: "リンクの後にスペースを入れません。",
+          column: 27,
+        },
+      ],
+    },
+    {
+      text: "これは[README](./README.md)おかしい",
+      output: "これは [README](./README.md) おかしい",
+      options: {
+        before: true,
+        after: true,
+      },
+      errors: [
+        {
+          message: "リンクの前にスペースを入れてください。",
+          column: 3,
+        },
+        {
+          message: "リンクの後にスペースを入れてください。",
+          column: 25,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Quick hack based on your existing [space-around-code](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code) package, as I have a use case which needs consistent spacing between `Syntax.Link` element.

I think someone have similar scenario so I made this as a pull request, but please feel free to discard this if you think it's not suited as one of rules of the preset. I can publish this as an independent textlint rule by myself. Thank you!
