### PR TITLE
fix: インラインコードの後にスペースを強制する処理が正常に動作していない不具合を修正

### DIFF
--- a/packages/textlint-rule-ja-space-around-code/src/index.js
+++ b/packages/textlint-rule-ja-space-around-code/src/index.js
@@ -49,7 +49,7 @@ function reporter(context, options) {
             // InlineCodeの後に文字が存在している時のみチェック
             if (existAfterChar) {
                 if (allowAfterSpace) {
-                    if (afterChar !== " " && isJapaneseChar(beforeChar)) {
+                    if (afterChar !== " " && isJapaneseChar(afterChar)) {
                         report(node, new RuleError("インラインコードの後にスペースを入れてください。", {
                             index: nodeText.length,
                             fix: fixer.insertTextAfterRange([0, nodeText.length], " ")

--- a/packages/textlint-rule-ja-space-around-code/test/index-test.js
+++ b/packages/textlint-rule-ja-space-around-code/test/index-test.js
@@ -94,6 +94,20 @@ tester.run("InlineCode周りのスペース", rule, {
                     column: 10
                 }
             ]
-        }
+        },
+             {
+            text: "これは`code`おかしい",
+            output: "これは`code` おかしい",
+            options: {
+                before: false,
+                after: true
+            },
+            errors: [
+                {
+                    message: "インラインコードの後にスペースを入れてください。",
+                    index: 9
+                }
+            ]
+        },
     ]
 });


### PR DESCRIPTION
`textlint-rule-ja-space-around-code` にて、`after: true` を設定したうえでインラインコードの後にスペースを入れなくてもエラーが発生しない問題を修正しました。

`isJapaneseChar` で調べている変数が正しくないために発生しているようです。

よろしくお願いいたします。