### PR TITLE
fix: リンクの後にスペースを強制する処理が正常に動作していない不具合を修正

### DIFF
--- a/packages/textlint-rule-ja-space-around-link/src/index.js
+++ b/packages/textlint-rule-ja-space-around-link/src/index.js
@@ -57,7 +57,7 @@ function reporter(context, options) {
       // InlineCodeの後に文字が存在している時のみチェック
       if (existAfterChar) {
         if (allowAfterSpace) {
-          if (afterChar !== " " && isJapaneseChar(beforeChar)) {
+          if (afterChar !== " " && isJapaneseChar(afterChar)) {
             report(
               node,
               new RuleError("リンクの後にスペースを入れてください。", {

--- a/packages/textlint-rule-ja-space-around-link/test/index-test.js
+++ b/packages/textlint-rule-ja-space-around-link/test/index-test.js
@@ -121,6 +121,34 @@ tester.run("Link周りのスペース", rule, {
     },
     {
       text: "これは[README](./README.md)おかしい",
+      output: "これは [README](./README.md)おかしい",
+      options: {
+        before: true,
+        after: false,
+      },
+      errors: [
+        {
+          message: "リンクの前にスペースを入れてください。",
+          column: 3,
+        },
+      ],
+    },
+    {
+      text: "これは[README](./README.md)おかしい",
+      output: "これは[README](./README.md) おかしい",
+      options: {
+        before: false,
+        after: true,
+      },
+      errors: [
+        {
+          message: "リンクの後にスペースを入れてください。",
+          column: 25,
+        },
+      ],
+    },
+    {
+      text: "これは[README](./README.md)おかしい",
       output: "これは [README](./README.md) おかしい",
       options: {
         before: true,


### PR DESCRIPTION
#26 と同じように、`textlint-rule-ja-space-around-link` にて、`after: true` を設定したうえでリンクの後にスペースを入れなくてもエラーが発生しない問題を修正しました。

昨日ご教示頂いたコードを参考にテストコードを書いたのですが、これで正しいのか自信が持てておりません。問題があればご指摘いただけたらと思います。

よろしくお願いいたします。