### PR TITLE
feat(space-between-half-and-full): add option to lint styled nodes

### DIFF
--- a/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
@@ -48,6 +48,9 @@ textlint --rule ja-space-between-half-and-full-width README.md
 - `exceptPunctuation`: `boolean`
     - デフォルト: `true`
     - 句読点（、。）を例外として扱うかどうか
+- `lintStyledNode`: `boolean`
+    - デフォルト: `false`
+    - プレーンテキスト以外(リンクや画像のキャプションなど)を lint の対象とするかどうか (プレーンテキストの判断基準は [textlint/textlint-rule-helper: This is helper library for creating textlint rule](https://github.com/textlint/textlint-rule-helper#rulehelperisplainstrnodenode-boolean) を参照してください)
     
 ```json
 {

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
@@ -12,7 +12,9 @@ const defaultOptions = {
     // "never" or "always"
     space: "never",
     // [。、,.]を例外とするかどうか
-    exceptPunctuation: true
+    exceptPunctuation: true,
+    // プレーンテキスト以外を対象とするか See https://github.com/textlint/textlint-rule-helper#rulehelperisplainstrnodenode-boolean
+    lintStyledNode: false,
 };
 function reporter(context, options = {}) {
     const {Syntax, RuleError, report, fixer, getSource} = context;
@@ -21,6 +23,9 @@ function reporter(context, options = {}) {
     const exceptPunctuation = options.exceptPunctuation !== undefined
         ? options.exceptPunctuation
         : defaultOptions.exceptPunctuation;
+    const lintStyledNode = options.lintStyledNode !== undefined
+        ? options.lintStyledNode
+        : defaultOptions.lintStyledNode;
     assert(spaceOption === "always" || spaceOption === "never", `"space" options should be "always" or "never".`);
     /**
      * `text`を対象に例外オプションを取り除くfilter関数を返す
@@ -76,7 +81,7 @@ function reporter(context, options = {}) {
     };
     return {
         [Syntax.Str](node){
-            if (!helper.isPlainStrNode(node)) {
+            if (!lintStyledNode && !helper.isPlainStrNode(node)) {
                 return;
             }
             const text = getSource(node);

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
@@ -187,6 +187,20 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             ]
         },
         {
+            text: "[Unicodeのサイト](https://home.unicode.org/)です。",
+            output: "[Unicode のサイト](https://home.unicode.org/)です。",
+            options: {
+                space: "always",
+                lintStyledNode: true
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 8
+                }
+            ]
+        },
+        {
             text: "日本語とenglishの間に半角スペースを入れる",
             output: "日本語と english の間に半角スペースを入れる",
             options: {


### PR DESCRIPTION
I have a use case which needs linting spacing for not only plain text but also heading, links, image captions, etc. This PR will add new option to allow this requirement. Please feel free to discard this PR if you think this is a niche scenario. I can publish this as an independent textlint rule by myself. Thank you!