### PR TITLE
feat(space-between-half-and-full-width): add an option to ignore numbers and apply only to alphabets

### DIFF
--- a/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
@@ -42,12 +42,13 @@ textlint --rule ja-space-between-half-and-full-width README.md
 
 ## Options
 
-- `space`: `"always"` || `"never"`
+- `space`: `"always"` || `"never"` || Array
     - デフォルト: `"never"`
     - スペースを常に 入れる(`"always"`) or 入れない(`"never"`)
-- `ignoreNumbers`: `boolean`
-    - デフォルト: `false`
-    - `space: "always"` の時のみ指定可能。半角数字を無視するかどうか
+    - Array 形式での指定も可能: `['alphabets', 'numbers', 'punctuation']`
+      - 対象としたい物のみ指定する
+      - 例えば、数値と句読点（、。）を例外として扱いたい場合は以下
+        - `['alphabets']`
 - `exceptPunctuation`: `boolean`
     - デフォルト: `true`
     - 句読点（、。）を例外として扱うかどうか

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
@@ -45,10 +45,10 @@ textlint --rule ja-space-between-half-and-full-width README.md
 - `space`: `"always"` || `"never"` || Array
     - デフォルト: `"never"`
     - スペースを常に 入れる(`"always"`) or 入れない(`"never"`)
-    - Array 形式での指定も可能: `['alphabets', 'numbers', 'punctuation']`
+    - Array 形式での指定も可能: `["alphabets", "numbers", "punctuation"]`
       - 対象としたい物のみ指定する
       - 例えば、数値と句読点（、。）を例外として扱いたい場合は以下
-        - `['alphabets']`
+        - `["alphabets"]`
 - `exceptPunctuation`: `boolean`
     - デフォルト: `true`
     - 句読点（、。）を例外として扱うかどうか
@@ -68,7 +68,7 @@ textlint --rule ja-space-between-half-and-full-width README.md
 
 `exceptPunctuation: true`とした場合は、句読点に関しては無視されるようになります。
 
-スペースは必須だが、`日本語、[alphabet]。`は許可する
+スペースは必須だが、`日本語、[alphabet]。`は許可する。
 
         text: "これは、Exception。",
         options: {

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
@@ -9,7 +9,7 @@
     OK: これはUnicode
     NG: これは Unicode
 
-全角文字には、句読点（、。）も含まれていますがデフォルトでは、`exceptPunctuation: true`であるため無視されます。
+全角文字には、句読点（、。）も含まれていますがデフォルトでは、有効であるため無視されます。
 
     OK: これも、Unicode。
 
@@ -42,16 +42,17 @@ textlint --rule ja-space-between-half-and-full-width README.md
 
 ## Options
 
-- `space`: `"always"` || `"never"` || Array
+- `space`: `"always"` || `"never"` || `string[]`
     - デフォルト: `"never"`
     - スペースを常に 入れる(`"always"`) or 入れない(`"never"`)
     - Array 形式での指定も可能: `["alphabets", "numbers", "punctuation"]`
       - 対象としたい物のみ指定する
       - 例えば、数値と句読点（、。）を例外として扱いたい場合は以下
         - `["alphabets"]`
-- `exceptPunctuation`: `boolean`
+- （非推奨）`exceptPunctuation`: `boolean`
     - デフォルト: `true`
     - 句読点（、。）を例外として扱うかどうか
+    - 代わりに `space` オプションを用いて `["alphabets", "numbers"]` と指定する
 - `lintStyledNode`: `boolean`
     - デフォルト: `false`
     - プレーンテキスト以外(リンクや画像のキャプションなど)を lint の対象とするかどうか (プレーンテキストの判断基準は [textlint/textlint-rule-helper: This is helper library for creating textlint rule](https://github.com/textlint/textlint-rule-helper#rulehelperisplainstrnodenode-boolean) を参照してください)
@@ -64,26 +65,24 @@ textlint --rule ja-space-between-half-and-full-width README.md
         }
     }
 }
-```   
+```
 
-`exceptPunctuation: true`とした場合は、句読点に関しては無視されるようになります。
+`space` オプションに `"punctuation"` を含めない場合は、句読点に関しては無視されるようになります。
 
 スペースは必須だが、`日本語、[alphabet]。`は許可する。
 
         text: "これは、Exception。",
         options: {
-            space: "always",
-            exceptPunctuation: true
+            space: ["alphabets", "numbers"]
         }
 
 スペースは不要だが、`日本語、 [alphabet] 。`は許可する。
 
         text: "これは、 Exception 。",
         options: {
-            space: "never",
-            exceptPunctuation: true
+            space: []
         }
-        
+
 
 ## Changelog
 

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/README.md
@@ -45,13 +45,16 @@ textlint --rule ja-space-between-half-and-full-width README.md
 - `space`: `"always"` || `"never"`
     - デフォルト: `"never"`
     - スペースを常に 入れる(`"always"`) or 入れない(`"never"`)
+- `ignoreNumbers`: `boolean`
+    - デフォルト: `false`
+    - `space: "always"` の時のみ指定可能。半角数字を無視するかどうか
 - `exceptPunctuation`: `boolean`
     - デフォルト: `true`
     - 句読点（、。）を例外として扱うかどうか
 - `lintStyledNode`: `boolean`
     - デフォルト: `false`
     - プレーンテキスト以外(リンクや画像のキャプションなど)を lint の対象とするかどうか (プレーンテキストの判断基準は [textlint/textlint-rule-helper: This is helper library for creating textlint rule](https://github.com/textlint/textlint-rule-helper#rulehelperisplainstrnodenode-boolean) を参照してください)
-    
+
 ```json
 {
     "rules": {

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
@@ -8,35 +8,48 @@ import {RuleHelper} from "textlint-rule-helper";
 import {matchCaptureGroupAll} from "match-index";
 const PunctuationRegExp = /[。、]/;
 const ZenRegExpStr = '[、。]|[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]|[ぁ-んァ-ヶ]'
+const spaceOptions = {
+  always: ['alphabets', 'numbers', 'punctuation'],
+  never: [],
+};
 const defaultOptions = {
     // スペースを入れるかどうか
-    // "never" or "always"
-    space: "never",
-    // 半角数字を無視するかどうか
-    // only works w/ space: "always"
-    ignoreNumbers: false,
+    // ("never"|"always"|Array)
+    space: spaceOptions.never,
     // [。、,.]を例外とするかどうか
     exceptPunctuation: true,
     // プレーンテキスト以外を対象とするか See https://github.com/textlint/textlint-rule-helper#rulehelperisplainstrnodenode-boolean
     lintStyledNode: false,
 };
 function reporter(context, options = {}) {
+   /**
+    * 入力された `space` オプションを内部処理用に成形する
+    * @param {string|Array|undefined} opt `space` オプションのインプット
+    * @returns {Array}
+    */
+    const parseSpaceOption = (opt) => {
+      let option = defaultOptions.space;
+      if (typeof opt === 'string') {
+         assert(opt === "always" || opt === "never", `"space" options should be "always", "never" or an array.`);
+        if (opt === 'always') option = spaceOptions.always
+      } else if (Array.isArray(opt)) {
+         assert(opt.every((v) => spaceOptions.always.includes(v)), `Only "alphabets", "numbers", "punctuation" should be included in the array.`);
+         option = opt;
+      }
+
+      return option;
+    }
+
     const {Syntax, RuleError, report, fixer, getSource} = context;
     const helper = new RuleHelper();
-    const spaceOption = options.space || defaultOptions.space;
-    const ignoreNumbers = options.ignoreNumbers !== undefined
-        ? options.ignoreNumbers
-        : defaultOptions.ignoreNumbers;
-    const exceptPunctuation = options.exceptPunctuation !== undefined
+    const spaceOption = parseSpaceOption(options.space);
+    let exceptPunctuation = spaceOption.includes('punctuation') ? true : undefined;
+    exceptPunctuation = options.exceptPunctuation !== undefined
         ? options.exceptPunctuation
         : defaultOptions.exceptPunctuation;
     const lintStyledNode = options.lintStyledNode !== undefined
         ? options.lintStyledNode
         : defaultOptions.lintStyledNode;
-    assert(spaceOption === "always" || spaceOption === "never", `"space" options should be "always" or "never".`);
-    if (spaceOption !== "always") {
-      assert(ignoreNumbers === false, `"ignoreNumbers" option can only work with "always" for the space option.`);
-    }
     /**
      * `text`を対象に例外オプションを取り除くfilter関数を返す
      * @param {string} text テスト対象のテキスト全体
@@ -76,19 +89,35 @@ function reporter(context, options = {}) {
     };
 
     // Always: アルファベットと全角の間はスペースを入れる
-    const needSpaceBetween = (node, text, ignoreNumbers) => {
-        const betweenHanAndZenRegExpStr = ignoreNumbers
-            ? `([A-Za-z])(?:${ZenRegExpStr})`
-            : `([A-Za-z0-9])(?:${ZenRegExpStr})`
-        const betweenZenAndHanRegExpStr = ignoreNumbers
-            ? `(${ZenRegExpStr})[A-Za-z]`
-            : `(${ZenRegExpStr})[A-Za-z0-9]`
-        const errorMsg = ignoreNumbers
-            ? "原則として、全角文字と数字以外の半角文字の間にスペースを入れます。"
-            : "原則として、全角文字と半角文字の間にスペースを入れます。"
+    const needSpaceBetween = (node, text, options) => {
+       /**
+        * オプションを元に正規表現オプジェクトを生成する
+        * @param {Array} opt `space` オプション
+        * @param {boolean} btwHanAndZen=true 半角全角の間か全角半角の間か
+        * @returns {Object}
+        */
+        const generateRegExp = (opt, btwHanAndZen = true) => {
+          const alphabets = 'A-Za-z';
+          const numbers = opt.includes('numbers') ? '0-9' : '';
 
-        const betweenHanAndZen = matchCaptureGroupAll(text, new RegExp(betweenHanAndZenRegExpStr));
-        const betweenZenAndHan = matchCaptureGroupAll(text, new RegExp(betweenZenAndHanRegExpStr));
+          let expStr;
+          if (btwHanAndZen) {
+            expStr = `([${alphabets}${numbers}])(?:${ZenRegExpStr})`;
+          } else {
+            expStr = `(${ZenRegExpStr})[${alphabets}${numbers}]`;
+          }
+
+          return new RegExp(expStr);
+        };
+
+        const betweenHanAndZenRegExp = generateRegExp(options);
+        const betweenZenAndHanRegExp = generateRegExp(options, false);
+        const errorMsg = options.includes('numbers')
+            ? "原則として、全角文字と半角文字の間にスペースを入れます。"
+            : "原則として、全角文字と数字以外の半角文字の間にスペースを入れます。"
+
+        const betweenHanAndZen = matchCaptureGroupAll(text, betweenHanAndZenRegExp);
+        const betweenZenAndHan = matchCaptureGroupAll(text, betweenZenAndHanRegExp);
         const reportMatch = (match) => {
             const {index} = match;
             report(node, new RuleError(errorMsg, {
@@ -106,10 +135,10 @@ function reporter(context, options = {}) {
             }
             const text = getSource(node);
 
-            if (spaceOption === "always") {
-                needSpaceBetween(node, text, ignoreNumbers)
-            } else if (spaceOption === "never") {
+          if (spaceOption.filter(opt => opt !== 'punctuation').length === 0) {
                 noSpaceBetween(node, text);
+            } else {
+                needSpaceBetween(node, text, spaceOption)
             }
 
         }

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
@@ -35,7 +35,7 @@ function reporter(context, options = {}) {
         : defaultOptions.lintStyledNode;
     assert(spaceOption === "always" || spaceOption === "never", `"space" options should be "always" or "never".`);
     if (spaceOption !== "always") {
-      assert(ignoreNumbers === false, `"ignoreNumbers" option can work only with "always" for the space option.`);
+      assert(ignoreNumbers === false, `"ignoreNumbers" option can only work with "always" for the space option.`);
     }
     /**
      * `text`を対象に例外オプションを取り除くfilter関数を返す

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
@@ -97,7 +97,7 @@ function reporter(context, options = {}) {
         * @returns {Object}
         */
         const generateRegExp = (opt, btwHanAndZen = true) => {
-          const alphabets = 'A-Za-z';
+          const alphabets = opt.includes('alphabets') ? 'A-Za-z' : '';
           const numbers = opt.includes('numbers') ? '0-9' : '';
 
           let expStr;
@@ -112,9 +112,7 @@ function reporter(context, options = {}) {
 
         const betweenHanAndZenRegExp = generateRegExp(options);
         const betweenZenAndHanRegExp = generateRegExp(options, false);
-        const errorMsg = options.includes('numbers')
-            ? "原則として、全角文字と半角文字の間にスペースを入れます。"
-            : "原則として、全角文字と数字以外の半角文字の間にスペースを入れます。"
+        const errorMsg = '原則として、全角文字と半角文字の間にスペースを入れます。'
 
         const betweenHanAndZen = matchCaptureGroupAll(text, betweenHanAndZenRegExp);
         const betweenZenAndHan = matchCaptureGroupAll(text, betweenZenAndHanRegExp);

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
@@ -25,22 +25,32 @@ function reporter(context, options = {}) {
     * @returns {Object}
     */
     const parseSpaceOption = (opt, exceptPunctuation) => {
-      let userOptions = {};
-
       if (typeof opt === 'string') {
         assert(opt === "always" || opt === "never", `"space" options should be "always", "never" or an array.`);
 
-        if (opt === 'always') userOptions = {...userOptions, alphabets: true, numbers: true};
-        if (exceptPunctuation === false) userOptions = { ...userOptions, punctuation: true };
+        if (opt === "always") {
+          if (exceptPunctuation === false) {
+            return {...defaultSpaceOptions, alphabets: true, numbers: true, punctuation: true};
+          } else {
+            return {...defaultSpaceOptions, alphabets: true, numbers: true};
+          }
+        } else if (opt === "never") {
+          if (exceptPunctuation === false) {
+            return {...defaultSpaceOptions, punctuation: true};
+          } else {
+            return defaultSpaceOptions;
+          }
+        }
       } else if (Array.isArray(opt)) {
         assert(
           opt.every((v) => Object.keys(defaultSpaceOptions).includes(v)),
           `Only "alphabets", "numbers", "punctuation" can be included in the array.`
         );
-        userOptions = Object.fromEntries(opt.map(key => [key, true]));
+        const userOptions = Object.fromEntries(opt.map(key => [key, true]));
+        return {...defaultSpaceOptions, ...userOptions};
       }
 
-      return {...defaultSpaceOptions, ...userOptions};
+      return defaultSpaceOptions;
     }
 
     const {Syntax, RuleError, report, fixer, getSource} = context;

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
@@ -7,11 +7,11 @@ const assert = require("assert");
 import {RuleHelper} from "textlint-rule-helper";
 import {matchCaptureGroupAll} from "match-index";
 const PunctuationRegExp = /[。、]/;
-const ZenRegExpStr = '[、。]|[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]|[ぁ-んァ-ヶ]'
+const ZenRegExpStr = '[、。]|[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]|[ぁ-んァ-ヶ]';
 const defaultSpaceOptions = {
-  alphabets: false,
-  numbers: false,
-  punctuation: false
+    alphabets: false,
+    numbers: false,
+    punctuation: false
 };
 const defaultOptions = {
     // プレーンテキスト以外を対象とするか See https://github.com/textlint/textlint-rule-helper#rulehelperisplainstrnodenode-boolean
@@ -21,17 +21,20 @@ function reporter(context, options = {}) {
    /**
     * 入力された `space` オプションを内部処理用に成形する
     * @param {string|Array|undefined} opt `space` オプションのインプット
-    * @returns {Array}
+    * @param {boolean|undefined} exceptPunctuation `exceptPunctuation` オプションのインプット
+    * @returns {Object}
     */
     const parseSpaceOption = (opt, exceptPunctuation) => {
       let option = {...defaultSpaceOptions};
 
       if (typeof opt === 'string') {
         assert(opt === "always" || opt === "never", `"space" options should be "always", "never" or an array.`);
+
         if (opt === 'always') option = { ...option, alphabets: true, numbers: true };
         if (exceptPunctuation === false) option = { ...option, punctuation: true };
       } else if (Array.isArray(opt)) {
-        assert(opt.every((v) => Object.keys(option).includes(v)), `Only "alphabets", "numbers", "punctuation" should be included in the array.`);
+        assert(opt.every((v) => Object.keys(option).includes(v)), `Only "alphabets", "numbers", "punctuation" can be included in the array.`);
+
         opt.map(key => option[key] = true);
       }
 
@@ -106,7 +109,7 @@ function reporter(context, options = {}) {
 
         const betweenHanAndZenRegExp = generateRegExp(options);
         const betweenZenAndHanRegExp = generateRegExp(options, false);
-        const errorMsg = '原則として、全角文字と半角文字の間にスペースを入れます。'
+        const errorMsg = '原則として、全角文字と半角文字の間にスペースを入れます。';
 
         const betweenHanAndZen = matchCaptureGroupAll(text, betweenHanAndZenRegExp);
         const betweenZenAndHan = matchCaptureGroupAll(text, betweenZenAndHanRegExp);
@@ -131,7 +134,7 @@ function reporter(context, options = {}) {
             if (Object.keys(spaceOption).every(noSpace)) {
                 noSpaceBetween(node, text);
             } else {
-                needSpaceBetween(node, text, spaceOption)
+                needSpaceBetween(node, text, spaceOption);
             }
         }
     }

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js
@@ -25,20 +25,22 @@ function reporter(context, options = {}) {
     * @returns {Object}
     */
     const parseSpaceOption = (opt, exceptPunctuation) => {
-      let option = {...defaultSpaceOptions};
+      let userOptions = {};
 
       if (typeof opt === 'string') {
         assert(opt === "always" || opt === "never", `"space" options should be "always", "never" or an array.`);
 
-        if (opt === 'always') option = { ...option, alphabets: true, numbers: true };
-        if (exceptPunctuation === false) option = { ...option, punctuation: true };
+        if (opt === 'always') userOptions = {...userOptions, alphabets: true, numbers: true};
+        if (exceptPunctuation === false) userOptions = { ...userOptions, punctuation: true };
       } else if (Array.isArray(opt)) {
-        assert(opt.every((v) => Object.keys(option).includes(v)), `Only "alphabets", "numbers", "punctuation" can be included in the array.`);
-
-        opt.map(key => option[key] = true);
+        assert(
+          opt.every((v) => Object.keys(defaultSpaceOptions).includes(v)),
+          `Only "alphabets", "numbers", "punctuation" can be included in the array.`
+        );
+        userOptions = Object.fromEntries(opt.map(key => [key, true]));
       }
 
-      return option;
+      return {...defaultSpaceOptions, ...userOptions};
     }
 
     const {Syntax, RuleError, report, fixer, getSource} = context;

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
@@ -8,6 +8,7 @@ tester.run("全角文字と半角文字の間", rule, {
         // デフォルト: never && exceptPunctuation
         "JTF標準",
         "これも、OK。",
+        "最新のversionは1.2.3です。",
         {
             text: "JTF標準",
             options: {
@@ -33,6 +34,12 @@ Pull Request、コミットのやりかたなどが書かれています。`,
         },
         {
             text: "日本語と english の間に半角スペースを入れる",
+            options: {
+                space: "always"
+            }
+        },
+        {
+            text: "最新の version は 1.2.3 です。",
             options: {
                 space: "always"
             }
@@ -75,6 +82,14 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 exceptPunctuation: true
             }
         },
+        // ignoreNumbers
+       {
+            text: "最新の version は1.2.3です。",
+            options: {
+                space: "always",
+                ignoreNumbers: true
+            }
+       }
     ],
     invalid: [
         {
@@ -217,6 +232,31 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 }
             ]
         },
+        {
+            text: "最新のversionは1.2.3です。",
+            output: "最新の version は 1.2.3 です。",
+            options: {
+                space: "always"
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 3
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 10
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 11
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 16
+                }
+            ]
+        },
         // with option
         {
             text: "aaaとbbb、cccとddd",
@@ -244,5 +284,24 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 }
             ]
         },
+        // ignoreNumbers
+        {
+            text: "最新のversionは1.2.3です。",
+            output: "最新の version は1.2.3です。",
+            options: {
+                space: "always",
+                ignoreNumbers: true
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と数字以外の半角文字の間にスペースを入れます。",
+                    column: 3
+                },
+                {
+                    message: "原則として、全角文字と数字以外の半角文字の間にスペースを入れます。",
+                    column: 10
+                }
+            ]
+        }
     ]
 });

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
@@ -41,7 +41,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
         {
             text: "最新の version は 1.2.3 です。",
             options: {
-                space: ["alphabets", "numbers", "punctuation"]
+                space: ["alphabets", "numbers"]
             }
         },
         // ignore
@@ -68,7 +68,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
         {
             text: "Always これは、Exception。",
             options: {
-                space: ["alphabets", "numbers", "punctuation"]
+                space: ["alphabets", "numbers"]
             },
         },
         // 入れても良い
@@ -82,7 +82,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
         {
             text: "Always これは 、 Exception 。",
             options: {
-                space: ["alphabets", "numbers", "punctuation"]
+                space: ["alphabets", "numbers"]
             },
         },
         {
@@ -223,7 +223,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             text: "JTF標準",
             output: "JTF 標準",
             options: {
-                space: ["alphabets", "numbers", "punctuation"]
+                space: ["alphabets", "numbers"]
             },
             errors: [
                 {

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
@@ -41,7 +41,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
         {
             text: "最新の version は 1.2.3 です。",
             options: {
-                space: ["numbers", "alphabets", "punctuation"]
+                space: ["alphabets", "numbers", "punctuation"]
             }
         },
         // ignore
@@ -68,7 +68,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
         {
             text: "Always これは、Exception。",
             options: {
-                space: ["numbers", "alphabets", "punctuation"],
+                space: ["alphabets", "numbers", "punctuation"]
             },
         },
         // 入れても良い
@@ -82,7 +82,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
         {
             text: "Always これは 、 Exception 。",
             options: {
-                space: ["numbers", "alphabets", "punctuation"],
+                space: ["alphabets", "numbers", "punctuation"]
             },
         },
         {
@@ -112,6 +112,13 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 space: [],
             }
         },
+        // ignoreAlphabets
+       {
+            text: "最新のversionは 1.2.3 です。",
+            options: {
+                space: ["numbers", "punctuation"]
+            }
+       },
         // ignoreNumbers
        {
             text: "最新の version は1.2.3です。",
@@ -216,7 +223,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             text: "JTF標準",
             output: "JTF 標準",
             options: {
-                space: ['numbers', 'alphabets', 'punctuation']
+                space: ["alphabets", "numbers", "punctuation"]
             },
             errors: [
                 {
@@ -339,6 +346,24 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 }
             ]
         },
+        // ignoreAlphabets
+        {
+            text: "最新のversionは1.2.3です。",
+            output: "最新のversionは 1.2.3 です。",
+            options: {
+                space: ["numbers", "punctuation"]
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 11
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 16
+                }
+            ]
+        },
         // ignoreNumbers
         {
             text: "最新のversionは1.2.3です。",
@@ -348,11 +373,11 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             },
             errors: [
                 {
-                    message: "原則として、全角文字と数字以外の半角文字の間にスペースを入れます。",
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
                     column: 3
                 },
                 {
-                    message: "原則として、全角文字と数字以外の半角文字の間にスペースを入れます。",
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
                     column: 10
                 }
             ]

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
@@ -41,7 +41,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
         {
             text: "最新の version は 1.2.3 です。",
             options: {
-                space: "always"
+                space: ["numbers", "alphabets", "punctuation"]
             }
         },
         // ignore
@@ -51,12 +51,24 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 space: "never"
             },
         },
+        {
+            text: "# JTF 標準",
+            options: {
+                space: []
+            },
+        },
         // except
         {
             text: "Always これは、Exception。",
             options: {
                 space: "always",
                 exceptPunctuation: true
+            },
+        },
+        {
+            text: "Always これは、Exception。",
+            options: {
+                space: ["numbers", "alphabets", "punctuation"],
             },
         },
         // 入れても良い
@@ -68,10 +80,22 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             },
         },
         {
+            text: "Always これは 、 Exception 。",
+            options: {
+                space: ["numbers", "alphabets", "punctuation"],
+            },
+        },
+        {
             text: "Never:これは、 Exception 。",
             options: {
                 space: "never",
                 exceptPunctuation: true
+            }
+        },
+        {
+            text: "Never:これは、 Exception 。",
+            options: {
+                space: []
             }
         },
         // 入れても良い
@@ -82,12 +106,17 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 exceptPunctuation: true
             }
         },
+        {
+            text: "Never:これは、Exception。",
+            options: {
+                space: [],
+            }
+        },
         // ignoreNumbers
        {
             text: "最新の version は1.2.3です。",
             options: {
-                space: "always",
-                ignoreNumbers: true
+                space: ["alphabets", "punctuation"]
             }
        }
     ],
@@ -107,6 +136,19 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             output: "JTF標準",
             options: {
                 space: "never"
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れません。",
+                    column: 4
+                }
+            ]
+        },
+        {
+            text: "JTF 標準",
+            output: "JTF標準",
+            options: {
+                space: []
             },
             errors: [
                 {
@@ -162,6 +204,19 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             output: "JTF 標準",
             options: {
                 space: "always"
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。",
+                    column: 3
+                }
+            ]
+        },
+        {
+            text: "JTF標準",
+            output: "JTF 標準",
+            options: {
+                space: ['numbers', 'alphabets', 'punctuation']
             },
             errors: [
                 {
@@ -289,8 +344,7 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             text: "最新のversionは1.2.3です。",
             output: "最新の version は1.2.3です。",
             options: {
-                space: "always",
-                ignoreNumbers: true
+                space: ["alphabets", "punctuation"]
             },
             errors: [
                 {


### PR DESCRIPTION
This PR tries to add an option to ignore numbers and apply only to alphabets.

Refs #40 

## 変更点

- `space`オプションにスペースを入れる対象の配列を指定できるように
  - `"space": ["alphabets", "numbers", "punctuation"]` でアルファベット、数値、句読点の前後にスペースを入れる(`"space": "always"`と同じ意味)
  - `"space": ["alphabets", "punctuation"]` とすると アルファベットと句読点の前後にスペースを入れる
  - `"space": []` で全てにスペースを入れない(`"space": "never"`と同じ意味)
- `exceptPunctuation` オプションは `"space": ["alphabets", "numbers"]`で代用できるため、非推奨となりました

## TEST
```json
// .textlintrc.json
{
    "rules": {
        "ja-space-between-half-and-full-width": {
            "space": "always",
            "ignoreNumbers": true
        }
    }
}
```

```md
## テスト

2022年7月7日、本日は晴天なり。
りんごは英語でAppleという。
```

```sh
>>> npx textlint old.md --fix

/Users/sho0628/projects/textlint_test/old.md
  4:7   ✔   原則として、全角文字と数字以外の半角文字の間にスペースを入れます。  ja-space-between-half-and-full-width
  4:12  ✔   原則として、全角文字と数字以外の半角文字の間にスペースを入れます。  ja-space-between-half-and-full-width

✔ Fixed 2 problems
```