### PR TITLE
fix(ja-space-between-half-and-full-widt): Collect dependencies

### DIFF
--- a/packages/textlint-rule-ja-space-between-half-and-full-width/package.json
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/package.json
@@ -29,10 +29,10 @@
     "textlintrule"
   ],
   "devDependencies": {
-    "@textlint/regexp-string-matcher": "^2.0.2",
     "textlint-scripts": "^13.3.3"
   },
   "dependencies": {
+    "@textlint/regexp-string-matcher": "^2.0.2",
     "match-index": "^1.0.1",
     "textlint-rule-helper": "^2.2.4"
   }


### PR DESCRIPTION
It was causing an error because it is being used here but was not included in the `dependencies`.

https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/blob/fd2a6cfd635146f6d3ffaf3e27dc5f58074e4c37/packages/textlint-rule-ja-space-between-half-and-full-width/src/index.js#L9

```
$ textlint --debug --preset preset-ja-spacing README.md
  textlint:cli cliOptions: {"debug":true,"preset":["preset-ja-spacing"],"ignorePath":"/.../.textlintignore","init":false,"stdin":false,"format":"stylish","color":true,"quiet":false,"textlintrc":true,"cache":false,"cacheLocation":"/.../.textlintcache","_":["README.md"]} +0ms
  textlint:cli textlint --version: 14.0.4 +0ms
  textlint:cli Running on files, stdin-filename: undefined +0ms
  textlint:cli-loader loadPackagesFromRawConfig failed: { ok: false, error: { message: 'Can not load rule', errors: [ [Error] ] } } +0ms
Error
Failed to load packages

Stack trace
Error: Failed to load packages
    at loadCliDescriptor (/.../node_modules/textlint/lib/src/loader/CliLoader.js:44:15)
    at async loadDescriptor (/.../node_modules/textlint/lib/src/cli.js:24:27)
    at async Object.executeWithOptions (/.../node_modules/textlint/lib/src/cli.js:111:28)
```
