### PR TITLE
refactor(ja-no-space-around-parentheses): replace match-index with String.prototype.matchAll

### DIFF
--- a/packages/textlint-rule-ja-no-space-around-parentheses/package.json
+++ b/packages/textlint-rule-ja-no-space-around-parentheses/package.json
@@ -32,7 +32,6 @@
     "textlint-scripts": "^13.3.3"
   },
   "dependencies": {
-    "match-index": "^1.0.3",
     "textlint-rule-helper": "^2.2.4"
   }
 }

--- a/packages/textlint-rule-ja-no-space-around-parentheses/src/index.js
+++ b/packages/textlint-rule-ja-no-space-around-parentheses/src/index.js
@@ -5,7 +5,6 @@
  かっこの外側、内側ともにスペースを入れません。
  */
 import { RuleHelper } from "textlint-rule-helper";
-import { matchCaptureGroupAll } from "match-index";
 
 const brackets = ["\\[", "\\]", "（", "）", "［", "］", "「", "」", "『", "』"];
 
@@ -26,29 +25,29 @@ function reporter(context) {
             const text = getSource(node);
             // 左にスペース
             leftBrackets.forEach((pattern) => {
-                matchCaptureGroupAll(text, pattern).forEach((match) => {
-                    const { index } = match;
+                for (const match of text.matchAll(pattern)) {
+                    const indexZeroBased = match.index;
                     report(
                         node,
                         new RuleError("かっこの外側、内側ともにスペースを入れません。", {
-                            index: index,
-                            fix: fixer.replaceTextRange([index, index + 1], "")
+                            index: indexZeroBased,
+                            fix: fixer.replaceTextRange([indexZeroBased, indexZeroBased + 1], "")
                         })
                     );
-                });
+                }
             });
             // 右にスペース
             rightBrackets.forEach((pattern) => {
-                matchCaptureGroupAll(text, pattern).forEach((match) => {
-                    const { index, text } = match;
+                for (const match of text.matchAll(pattern)) {
+                    const indexOnebased = match.index + 1;
                     report(
                         node,
                         new RuleError("かっこの外側、内側ともにスペースを入れません。", {
-                            index: index,
-                            fix: fixer.replaceTextRange([index, index + 1], "")
+                            index: indexOnebased,
+                            fix: fixer.replaceTextRange([indexOnebased, indexOnebased + 1], "")
                         })
                     );
-                });
+                }
             });
         }
     };


### PR DESCRIPTION
Replace match-index with String.prototype.matchAll.
Ref. https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues/55
