### PR TITLE
refactor(ja-space-between-half-and-full-width): replace match-index with String.prototype.matchAll

### DIFF
--- a/packages/textlint-rule-ja-space-between-half-and-full-width/package.json
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@textlint/regexp-string-matcher": "^2.0.2",
-    "match-index": "^1.0.1",
     "textlint-rule-helper": "^2.2.4"
   }
 }


### PR DESCRIPTION
Replace match-index with String.prototype.matchAll.
Ref. https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues/55