### PR TITLE
feat: add space-around rules for emphasis and strong

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,20 @@ textlint --preset preset-ja-spacing README.md
 インラインコードの周りをスペースで囲むかどうかを決めるルール。
 デフォルトでは、インラインコードの周りをスペースで囲みません。
 
+### [textlint-rule-ja-space-around-emphasis](packages/textlint-rule-ja-space-around-emphasis)
+
+強調の周りをスペースで囲むかどうかを決めるルール。
+デフォルトでは、強調の周りをスペースで囲みません。
+
 ### [textlint-rule-ja-space-around-link](packages/textlint-rule-ja-space-around-link)
 
 リンクの周りをスペースで囲むかどうかを決めるルール。
 デフォルトでは、リンクの周りをスペースで囲みません。
+
+### [textlint-rule-ja-space-around-strong](packages/textlint-rule-ja-space-around-strong)
+
+強い強調の周りをスペースで囲むかどうかを決めるルール。
+デフォルトでは、強い強調の周りをスペースで囲みません。
 
 ## デフォルト設定
 
@@ -97,7 +107,9 @@ textlint --preset preset-ja-spacing README.md
              "ja-space-after-exclamation": true,
              "ja-space-after-question": true,
              "ja-space-around-code": false,
-             "ja-space-around-link": false
+             "ja-space-around-emphasis": false,
+             "ja-space-around-link": false,
+             "ja-space-around-strong": false
          }
     }
 }
@@ -106,7 +118,9 @@ textlint --preset preset-ja-spacing README.md
 またデフォルトでは、次のルールは無効の状態でプリセットに含まれています。
 
 - [textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code)
+- [textlint-rule-ja-space-around-emphasis](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-emphasis)
 - [textlint-rule-ja-space-around-link](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-link)
+- [textlint-rule-ja-space-around-strong](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-strong)
 
 次のように設定することで、ルールを有効にできます。
 ルールのオプションについての詳細はそれぞれのパッケージのREADMEを参照してください。
@@ -116,7 +130,9 @@ textlint --preset preset-ja-spacing README.md
     "rules": {
         "preset-ja-spacing": {
             "ja-space-around-code": true,
-            "ja-space-around-link": true
+            "ja-space-around-emphasis": true,
+            "ja-space-around-link": true,
+            "ja-space-around-strong": true
         }
     }
 }

--- a/packages/textlint-rule-ja-space-around-emphasis/CHANGELOG.md
+++ b/packages/textlint-rule-ja-space-around-emphasis/CHANGELOG.md
@@ -1,0 +1,5 @@
+# textlint-rule-ja-space-around-emphasis
+
+## 2.4.2
+
+- Initial release.

--- a/packages/textlint-rule-ja-space-around-emphasis/LICENSE
+++ b/packages/textlint-rule-ja-space-around-emphasis/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/textlint-rule-ja-space-around-emphasis/README.md
+++ b/packages/textlint-rule-ja-space-around-emphasis/README.md
@@ -1,0 +1,94 @@
+# textlint-rule-ja-space-around-emphasis [![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+
+強調の周りをスペースで囲むかどうかを決めるtextlintルール
+
+強調とは[TxtAST](https://github.com/textlint/textlint/blob/master/docs/txtnode.md "TxtAST")の`Emphasis` nodeのことです。
+
+このルールでは、強調の前後が日本語である場合に半角スペースを入れるかを決定します。
+オプションでスペースの有無を決定できます。
+
+    *emphasis* と日本語の間はスペースを空ける
+    *emphasis*と日本語の間はスペースを空けない
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install textlint-rule-ja-space-around-emphasis
+
+## Usage
+
+Via `.textlintrc`(Recommended)
+
+```json
+{
+    "rules": {
+        "ja-space-around-emphasis": true
+    }
+}
+```
+
+Via CLI
+
+```
+textlint --rule ja-space-around-emphasis README.md
+```
+
+## Options
+
+- `before`: `boolean`
+    - デフォルト: `false`
+    - `true`なら、`Emphasis`の前に半角スペースを入れる
+- `after`: `boolean`
+    - デフォルト: `false`
+    - `true`なら、`Emphasis`の後に半角スペースを入れる
+
+デフォルト値は次のようになります。
+
+```json
+{
+    "rules": {
+        "ja-space-around-emphasis": {
+            "before": false,
+            "after": false
+        }
+    }
+}
+```
+
+## Fixable
+
+[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+
+`textlint --fix`の自動修正に対応しています。
+
+## Changelog
+
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm i -d && npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/textlint-rule-ja-space-around-emphasis/package.json
+++ b/packages/textlint-rule-ja-space-around-emphasis/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "textlint-rule-preset-ja-spacing",
-  "version": "2.4.3",
-  "description": "textlint-rule-preset-ja-spacingのルールプリセット",
+  "name": "textlint-rule-ja-space-around-emphasis",
+  "version": "2.4.2",
+  "description": "強調の周りをスペースで囲むかどうかを決めるtextlintルール",
   "main": "lib/index.js",
   "files": [
     "src/",
@@ -32,15 +32,7 @@
     "textlint-scripts": "^13.3.3"
   },
   "dependencies": {
-    "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^2.4.3",
-    "textlint-rule-ja-no-space-around-parentheses": "^2.4.2",
-    "textlint-rule-ja-no-space-between-full-width": "^2.4.2",
-    "textlint-rule-ja-space-after-exclamation": "^2.4.2",
-    "textlint-rule-ja-space-after-question": "^2.4.2",
-    "textlint-rule-ja-space-around-code": "^2.4.2",
-    "textlint-rule-ja-space-around-emphasis": "^2.4.2",
-    "textlint-rule-ja-space-around-link": "^2.4.2",
-    "textlint-rule-ja-space-around-strong": "^2.4.2",
-    "textlint-rule-ja-space-between-half-and-full-width": "^2.4.2"
+    "match-index": "^1.0.1",
+    "textlint-rule-helper": "^2.2.4"
   }
 }

--- a/packages/textlint-rule-ja-space-around-emphasis/src/index.js
+++ b/packages/textlint-rule-ja-space-around-emphasis/src/index.js
@@ -1,0 +1,84 @@
+// LICENSE : MIT
+"use strict";
+const isJapaneseChar = (text) => {
+    return /^(?:[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]|[ぁ-んァ-ヶ])$/.test(text);
+};
+const defaultOptions = {
+    before: false,
+    after: false
+};
+function reporter(context, options = {}) {
+    const { Syntax, RuleError, report, fixer, getSource } = context;
+    const allowBeforeSpace = options.before || defaultOptions.before;
+    const allowAfterSpace = options.after || defaultOptions.after;
+    return {
+        [Syntax.Emphasis](node) {
+            const nodeText = getSource(node);
+            // Emphasisの前後2文字文を取得
+            // スペース + 前後の文字を取るため
+            // 文字が日本語以外はチェック対象にしないようにするため
+            const textWithPadding = getSource(node, 2, 2);
+            if (!textWithPadding) {
+                return;
+            }
+            const beforeChar = textWithPadding[1];
+            const beforeBeforeChar = textWithPadding[0];
+            const existBeforeChar = nodeText[0] !== beforeChar;
+            const afterChar = textWithPadding[textWithPadding.length - 2];
+            const afterAfterChar = textWithPadding[textWithPadding.length - 1];
+            const existAfterChar = nodeText[textWithPadding.length - 1] !== afterChar;
+            // Emphasisの前に文字が存在している時のみチェック
+            if (existBeforeChar) {
+                if (allowBeforeSpace) {
+                    if (beforeChar !== " " && isJapaneseChar(beforeChar)) {
+                        report(
+                            node,
+                            new RuleError("強調の前にスペースを入れてください。", {
+                                index: -1,
+                                fix: fixer.insertTextBeforeRange([0, 0], " ")
+                            })
+                        );
+                    }
+                } else {
+                    if (beforeChar === " " && isJapaneseChar(beforeBeforeChar)) {
+                        report(
+                            node,
+                            new RuleError("強調の前にスペースを入れません。", {
+                                index: -1,
+                                fix: fixer.replaceTextRange([-1, 0], "")
+                            })
+                        );
+                    }
+                }
+            }
+            // Emphasisの後に文字が存在している時のみチェック
+            if (existAfterChar) {
+                if (allowAfterSpace) {
+                    if (afterChar !== " " && isJapaneseChar(afterChar)) {
+                        report(
+                            node,
+                            new RuleError("強調の後にスペースを入れてください。", {
+                                index: nodeText.length,
+                                fix: fixer.insertTextAfterRange([0, nodeText.length], " ")
+                            })
+                        );
+                    }
+                } else {
+                    if (afterChar === " " && isJapaneseChar(afterAfterChar)) {
+                        report(
+                            node,
+                            new RuleError("強調の後にスペースを入れません。", {
+                                index: nodeText.length + 1,
+                                fix: fixer.replaceTextRange([nodeText.length, nodeText.length + 1], "")
+                            })
+                        );
+                    }
+                }
+            }
+        }
+    };
+}
+module.exports = {
+    linter: reporter,
+    fixer: reporter
+};

--- a/packages/textlint-rule-ja-space-around-emphasis/test/index-test.js
+++ b/packages/textlint-rule-ja-space-around-emphasis/test/index-test.js
@@ -1,0 +1,96 @@
+// LICENSE : MIT
+"use strict";
+import TextLintTester from "textlint-tester";
+import rule from "../src/index";
+var tester = new TextLintTester();
+tester.run("Emphasis周りのスペース", rule, {
+    valid: [
+        {
+            text: "*emphasis* と日本語の間はスペースを空ける",
+            options: {
+                before: true,
+                after: true
+            }
+        },
+        {
+            text: "*emphasis*と日本語の間はスペースを空けない",
+            options: {
+                before: false,
+                after: false
+            }
+        },
+        {
+            text: "*emphasis* is good in english text.",
+            options: {
+                before: false,
+                after: false
+            }
+        }
+    ],
+    invalid: [
+        {
+            text: "これは *emphasis* おかしい",
+            output: "これは *emphasis*おかしい",
+            options: {
+                before: true,
+                after: false
+            },
+            errors: [
+                {
+                    message: "強調の後にスペースを入れません。",
+                    column: 16
+                }
+            ]
+        },
+        {
+            text: "これは *emphasis* おかしい",
+            output: "これは*emphasis* おかしい",
+            options: {
+                before: false,
+                after: true
+            },
+            errors: [
+                {
+                    message: "強調の前にスペースを入れません。",
+                    column: 4
+                }
+            ]
+        },
+        {
+            text: "これは *emphasis* おかしい",
+            output: "これは*emphasis*おかしい",
+            options: {
+                before: false,
+                after: false
+            },
+            errors: [
+                {
+                    message: "強調の前にスペースを入れません。",
+                    column: 4
+                },
+                {
+                    message: "強調の後にスペースを入れません。",
+                    column: 16
+                }
+            ]
+        },
+        {
+            text: "これは*emphasis*おかしい",
+            output: "これは *emphasis* おかしい",
+            options: {
+                before: true,
+                after: true
+            },
+            errors: [
+                {
+                    message: "強調の前にスペースを入れてください。",
+                    column: 3
+                },
+                {
+                    message: "強調の後にスペースを入れてください。",
+                    column: 14
+                }
+            ]
+        }
+    ]
+});

--- a/packages/textlint-rule-ja-space-around-strong/CHANGELOG.md
+++ b/packages/textlint-rule-ja-space-around-strong/CHANGELOG.md
@@ -1,0 +1,5 @@
+# textlint-rule-ja-space-around-strong
+
+## 2.4.2
+
+- Initial release.

--- a/packages/textlint-rule-ja-space-around-strong/LICENSE
+++ b/packages/textlint-rule-ja-space-around-strong/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/textlint-rule-ja-space-around-strong/README.md
+++ b/packages/textlint-rule-ja-space-around-strong/README.md
@@ -1,0 +1,94 @@
+# textlint-rule-ja-space-around-strong [![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+
+強い強調の周りをスペースで囲むかどうかを決めるtextlintルール
+
+強い強調とは[TxtAST](https://github.com/textlint/textlint/blob/master/docs/txtnode.md "TxtAST")の`Strong` nodeのことです。
+
+このルールでは、強い強調の前後が日本語である場合に半角スペースを入れるかを決定します。
+オプションでスペースの有無を決定できます。
+
+    **strong** と日本語の間はスペースを空ける
+    **strong**と日本語の間はスペースを空けない
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install textlint-rule-ja-space-around-strong
+
+## Usage
+
+Via `.textlintrc`(Recommended)
+
+```json
+{
+    "rules": {
+        "ja-space-around-strong": true
+    }
+}
+```
+
+Via CLI
+
+```
+textlint --rule ja-space-around-strong README.md
+```
+
+## Options
+
+- `before`: `boolean`
+    - デフォルト: `false`
+    - `true`なら、`Strong`の前に半角スペースを入れる
+- `after`: `boolean`
+    - デフォルト: `false`
+    - `true`なら、`Strong`の後に半角スペースを入れる
+
+デフォルト値は次のようになります。
+
+```json
+{
+    "rules": {
+        "ja-space-around-strong": {
+            "before": false,
+            "after": false
+        }
+    }
+}
+```
+
+## Fixable
+
+[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+
+`textlint --fix`の自動修正に対応しています。
+
+## Changelog
+
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm i -d && npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/textlint-rule-ja-space-around-strong/package.json
+++ b/packages/textlint-rule-ja-space-around-strong/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "textlint-rule-preset-ja-spacing",
-  "version": "2.4.3",
-  "description": "textlint-rule-preset-ja-spacingのルールプリセット",
+  "name": "textlint-rule-ja-space-around-strong",
+  "version": "2.4.2",
+  "description": "強い強調の周りをスペースで囲むかどうかを決めるtextlintルール",
   "main": "lib/index.js",
   "files": [
     "src/",
@@ -32,15 +32,7 @@
     "textlint-scripts": "^13.3.3"
   },
   "dependencies": {
-    "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^2.4.3",
-    "textlint-rule-ja-no-space-around-parentheses": "^2.4.2",
-    "textlint-rule-ja-no-space-between-full-width": "^2.4.2",
-    "textlint-rule-ja-space-after-exclamation": "^2.4.2",
-    "textlint-rule-ja-space-after-question": "^2.4.2",
-    "textlint-rule-ja-space-around-code": "^2.4.2",
-    "textlint-rule-ja-space-around-emphasis": "^2.4.2",
-    "textlint-rule-ja-space-around-link": "^2.4.2",
-    "textlint-rule-ja-space-around-strong": "^2.4.2",
-    "textlint-rule-ja-space-between-half-and-full-width": "^2.4.2"
+    "match-index": "^1.0.1",
+    "textlint-rule-helper": "^2.2.4"
   }
 }

--- a/packages/textlint-rule-ja-space-around-strong/src/index.js
+++ b/packages/textlint-rule-ja-space-around-strong/src/index.js
@@ -1,0 +1,84 @@
+// LICENSE : MIT
+"use strict";
+const isJapaneseChar = (text) => {
+    return /^(?:[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF]|[ぁ-んァ-ヶ])$/.test(text);
+};
+const defaultOptions = {
+    before: false,
+    after: false
+};
+function reporter(context, options = {}) {
+    const { Syntax, RuleError, report, fixer, getSource } = context;
+    const allowBeforeSpace = options.before || defaultOptions.before;
+    const allowAfterSpace = options.after || defaultOptions.after;
+    return {
+        [Syntax.Strong](node) {
+            const nodeText = getSource(node);
+            // Strongの前後2文字文を取得
+            // スペース + 前後の文字を取るため
+            // 文字が日本語以外はチェック対象にしないようにするため
+            const textWithPadding = getSource(node, 2, 2);
+            if (!textWithPadding) {
+                return;
+            }
+            const beforeChar = textWithPadding[1];
+            const beforeBeforeChar = textWithPadding[0];
+            const existBeforeChar = nodeText[0] !== beforeChar;
+            const afterChar = textWithPadding[textWithPadding.length - 2];
+            const afterAfterChar = textWithPadding[textWithPadding.length - 1];
+            const existAfterChar = nodeText[textWithPadding.length - 1] !== afterChar;
+            // Strongの前に文字が存在している時のみチェック
+            if (existBeforeChar) {
+                if (allowBeforeSpace) {
+                    if (beforeChar !== " " && isJapaneseChar(beforeChar)) {
+                        report(
+                            node,
+                            new RuleError("強い強調の前にスペースを入れてください。", {
+                                index: -1,
+                                fix: fixer.insertTextBeforeRange([0, 0], " ")
+                            })
+                        );
+                    }
+                } else {
+                    if (beforeChar === " " && isJapaneseChar(beforeBeforeChar)) {
+                        report(
+                            node,
+                            new RuleError("強い強調の前にスペースを入れません。", {
+                                index: -1,
+                                fix: fixer.replaceTextRange([-1, 0], "")
+                            })
+                        );
+                    }
+                }
+            }
+            // Strongの後に文字が存在している時のみチェック
+            if (existAfterChar) {
+                if (allowAfterSpace) {
+                    if (afterChar !== " " && isJapaneseChar(afterChar)) {
+                        report(
+                            node,
+                            new RuleError("強い強調の後にスペースを入れてください。", {
+                                index: nodeText.length,
+                                fix: fixer.insertTextAfterRange([0, nodeText.length], " ")
+                            })
+                        );
+                    }
+                } else {
+                    if (afterChar === " " && isJapaneseChar(afterAfterChar)) {
+                        report(
+                            node,
+                            new RuleError("強い強調の後にスペースを入れません。", {
+                                index: nodeText.length + 1,
+                                fix: fixer.replaceTextRange([nodeText.length, nodeText.length + 1], "")
+                            })
+                        );
+                    }
+                }
+            }
+        }
+    };
+}
+module.exports = {
+    linter: reporter,
+    fixer: reporter
+};

--- a/packages/textlint-rule-ja-space-around-strong/test/index-test.js
+++ b/packages/textlint-rule-ja-space-around-strong/test/index-test.js
@@ -1,0 +1,96 @@
+// LICENSE : MIT
+"use strict";
+import TextLintTester from "textlint-tester";
+import rule from "../src/index";
+var tester = new TextLintTester();
+tester.run("Strong周りのスペース", rule, {
+    valid: [
+        {
+            text: "**strong** と日本語の間はスペースを空ける",
+            options: {
+                before: true,
+                after: true
+            }
+        },
+        {
+            text: "**strong**と日本語の間はスペースを空けない",
+            options: {
+                before: false,
+                after: false
+            }
+        },
+        {
+            text: "**strong** is good in english text.",
+            options: {
+                before: false,
+                after: false
+            }
+        }
+    ],
+    invalid: [
+        {
+            text: "これは **strong** おかしい",
+            output: "これは **strong**おかしい",
+            options: {
+                before: true,
+                after: false
+            },
+            errors: [
+                {
+                    message: "強い強調の後にスペースを入れません。",
+                    column: 16
+                }
+            ]
+        },
+        {
+            text: "これは **strong** おかしい",
+            output: "これは**strong** おかしい",
+            options: {
+                before: false,
+                after: true
+            },
+            errors: [
+                {
+                    message: "強い強調の前にスペースを入れません。",
+                    column: 4
+                }
+            ]
+        },
+        {
+            text: "これは **strong** おかしい",
+            output: "これは**strong**おかしい",
+            options: {
+                before: false,
+                after: false
+            },
+            errors: [
+                {
+                    message: "強い強調の前にスペースを入れません。",
+                    column: 4
+                },
+                {
+                    message: "強い強調の後にスペースを入れません。",
+                    column: 16
+                }
+            ]
+        },
+        {
+            text: "これは**strong**おかしい",
+            output: "これは **strong** おかしい",
+            options: {
+                before: true,
+                after: true
+            },
+            errors: [
+                {
+                    message: "強い強調の前にスペースを入れてください。",
+                    column: 3
+                },
+                {
+                    message: "強い強調の後にスペースを入れてください。",
+                    column: 14
+                }
+            ]
+        }
+    ]
+});

--- a/packages/textlint-rule-preset-ja-spacing/README.md
+++ b/packages/textlint-rule-preset-ja-spacing/README.md
@@ -36,7 +36,12 @@ textlint --preset ja-spacing README.md
 
 ## Options
 
-デフォルトでは、[textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code)は無効になっています。
+デフォルトでは、次のルールは無効になっています。
+
+- [textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code)
+- [textlint-rule-ja-space-around-emphasis](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-emphasis)
+- [textlint-rule-ja-space-around-link](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-link)
+- [textlint-rule-ja-space-around-strong](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-strong)
 
 次のように設定することで、プリセットに含まれるすべてのルールを有効にできます。
 
@@ -45,6 +50,18 @@ textlint --preset ja-spacing README.md
     "rules": {
         "preset-ja-spacing": {
             "ja-space-around-code": {
+                "before": false,
+                "after": false
+            },
+            "ja-space-around-emphasis": {
+                "before": false,
+                "after": false
+            },
+            "ja-space-around-link": {
+                "before": false,
+                "after": false
+            },
+            "ja-space-around-strong": {
                 "before": false,
                 "after": false
             }

--- a/packages/textlint-rule-preset-ja-spacing/src/index.js
+++ b/packages/textlint-rule-preset-ja-spacing/src/index.js
@@ -9,7 +9,9 @@ module.exports = {
         "ja-space-after-exclamation": require("textlint-rule-ja-space-after-exclamation"),
         "ja-space-after-question": require("textlint-rule-ja-space-after-question"),
         "ja-space-around-code": require("textlint-rule-ja-space-around-code"),
-        "ja-space-around-link": require("textlint-rule-ja-space-around-link")
+        "ja-space-around-emphasis": require("textlint-rule-ja-space-around-emphasis"),
+        "ja-space-around-link": require("textlint-rule-ja-space-around-link"),
+        "ja-space-around-strong": require("textlint-rule-ja-space-around-strong")
     },
     rulesConfig: {
         "ja-nakaguro-or-halfwidth-space-between-katakana": true,
@@ -21,6 +23,8 @@ module.exports = {
         "ja-space-after-exclamation": true,
         "ja-space-after-question": true,
         "ja-space-around-code": false,
-        "ja-space-around-link": false
+        "ja-space-around-emphasis": false,
+        "ja-space-around-link": false,
+        "ja-space-around-strong": false
     }
 };


### PR DESCRIPTION
このPRでは`Emphasis`と`Strong`ノードの周りをスペースで囲むかどうかを決めるtextlintルールを追加します。追加されるルールは既存のものに合わせてデフォルトでは無効にしています[^1]。

[^1]: https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues/54