### PR TITLE
feat: enable space-around rules by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,34 +106,11 @@ textlint --preset preset-ja-spacing README.md
              },
              "ja-space-after-exclamation": true,
              "ja-space-after-question": true,
-             "ja-space-around-code": false,
-             "ja-space-around-emphasis": false,
-             "ja-space-around-link": false,
-             "ja-space-around-strong": false
+             "ja-space-around-code": true,
+             "ja-space-around-emphasis": true,
+             "ja-space-around-link": true,
+             "ja-space-around-strong": true
          }
-    }
-}
-```
-
-またデフォルトでは、次のルールは無効の状態でプリセットに含まれています。
-
-- [textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code)
-- [textlint-rule-ja-space-around-emphasis](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-emphasis)
-- [textlint-rule-ja-space-around-link](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-link)
-- [textlint-rule-ja-space-around-strong](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-strong)
-
-次のように設定することで、ルールを有効にできます。
-ルールのオプションについての詳細はそれぞれのパッケージのREADMEを参照してください。
-
-```json
-{
-    "rules": {
-        "preset-ja-spacing": {
-            "ja-space-around-code": true,
-            "ja-space-around-emphasis": true,
-            "ja-space-around-link": true,
-            "ja-space-around-strong": true
-        }
     }
 }
 ```

--- a/packages/textlint-rule-preset-ja-spacing/README.md
+++ b/packages/textlint-rule-preset-ja-spacing/README.md
@@ -34,42 +34,6 @@ textlint --preset ja-spacing README.md
 ```
 
 
-## Options
-
-デフォルトでは、次のルールは無効になっています。
-
-- [textlint-rule-ja-space-around-code](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-code)
-- [textlint-rule-ja-space-around-emphasis](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-emphasis)
-- [textlint-rule-ja-space-around-link](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-link)
-- [textlint-rule-ja-space-around-strong](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/tree/master/packages/textlint-rule-ja-space-around-strong)
-
-次のように設定することで、プリセットに含まれるすべてのルールを有効にできます。
-
-```json
-{
-    "rules": {
-        "preset-ja-spacing": {
-            "ja-space-around-code": {
-                "before": false,
-                "after": false
-            },
-            "ja-space-around-emphasis": {
-                "before": false,
-                "after": false
-            },
-            "ja-space-around-link": {
-                "before": false,
-                "after": false
-            },
-            "ja-space-around-strong": {
-                "before": false,
-                "after": false
-            }
-        }
-    }
-}
-```
-
 ## Changelog
 
 See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).

--- a/packages/textlint-rule-preset-ja-spacing/src/index.js
+++ b/packages/textlint-rule-preset-ja-spacing/src/index.js
@@ -22,9 +22,9 @@ module.exports = {
         },
         "ja-space-after-exclamation": true,
         "ja-space-after-question": true,
-        "ja-space-around-code": false,
-        "ja-space-around-emphasis": false,
-        "ja-space-around-link": false,
-        "ja-space-around-strong": false
+        "ja-space-around-code": true,
+        "ja-space-around-emphasis": true,
+        "ja-space-around-link": true,
+        "ja-space-around-strong": true
     }
 };


### PR DESCRIPTION
close #54

Prettier v3でのCJK文字の扱いの仕様変更[^1]や、CSSの`text-autospace`プロパティの提案[^2][^3]などの動向を踏まえると、デフォルトでスペースを挿入しないように設定して良いように思います。textlintが導入されている著名なOSSドキュメントの一つに[Astro](https://github.com/withastro/docs/)がありますが、ここの[日本語翻訳ガイド](https://github.com/withastro/docs/blob/main/i18n-guides/%E6%97%A5%E6%9C%AC%E8%AA%9E.md)に書かれている意思決定の理由は参考になるかもしれません。

[^1]: https://prettier.io/blog/2023/07/05/3.0.0.html#markdown
[^2]: https://developer.mozilla.org/ja/docs/Web/CSS/Reference/Properties/text-autospace
[^3]: https://qiita.com/debiru/items/1b4a5aa73fe5c952e104