### PR TITLE
fix: gh release create が --json 非対応のため修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,7 @@ jobs:
         run: |
           RELEASE_URL=$(gh release create "v${PACKAGE_VERSION}" \
             --title "${GITHUB_EVENT_PULL_REQUEST_TITLE}" \
-            --notes "${GITHUB_EVENT_PULL_REQUEST_BODY}" \
-            --json url -q .url)
+            --notes "${GITHUB_EVENT_PULL_REQUEST_BODY}")
           echo "release-url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
           echo "released=true" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
## Summary

リリースワークフローの `gh release create` コマンドが `--json`/`-q` オプションを使用していたが、`gh release create` はこれらのオプションをサポートしていないためエラーになっていた。該当オプションを削除して修正する。

## Changes

- `.github/workflows/release.yml` の `gh release create` から `--json url -q .url` を削除
- `RELEASE_URL` は `gh release create` の標準出力（作成されたリリースのURL）をそのまま受け取る形に変更

## Breaking Changes

None

## Test Plan

- リリースワークフローを実行し、`gh release create` がエラーなく完了することを確認する
- `release-url` の出力に作成されたGitHub ReleaseのURLが正しくセットされることを確認する