### PR TITLE
ci: 必須チェックを集約する automerge-gate を追加

### DIFF
--- a/.github/workflows/automerge-gate.yaml
+++ b/.github/workflows/automerge-gate.yaml
@@ -1,0 +1,25 @@
+name: automerge-gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, auto_merge_enabled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  gate:
+    name: automerge-gate/all-passed
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      checks: read
+      pull-requests: read
+      actions: read
+    steps:
+      - uses: pkgdeps/automerge-gate@fe5d7cd2fc17778dc42f6916f9d9990cb259ad01 # v5.0.0
+        with:
+          gate-mode: "public"


### PR DESCRIPTION
## Summary

`pkgdeps/automerge-gate` を使い、PRのすべての必須チェックが通過したことを集約する `automerge-gate` ワークフローを追加します。これにより、自動マージのゲートとして単一のステータスチェックを利用できるようになります。

## Changes

- `.github/workflows/automerge-gate.yaml` を新規追加
  - `pull_request` の `opened` / `synchronize` / `reopened` / `auto_merge_enabled` をトリガーに実行
  - `pkgdeps/automerge-gate@v5.0.0` を `gate-mode: public` で実行し、全チェックの通過を集約
  - `permissions: {}` をデフォルトとし、jobレベルで `checks: read` / `pull-requests: read` / `actions: read` のみ付与
  - `concurrency` で同一refの実行をキャンセル

## Breaking Changes

None

## Test Plan

- このPR自体で `automerge-gate/all-passed` チェックが実行され、他の必須チェックの結果を集約することを確認する