### PR TITLE
fix: migrate website deploy to official GitHub Pages actions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,25 +5,34 @@ on:
       - master
   workflow_dispatch:
 
+# 既定の権限は読み取りのみにし、必要な権限はジョブ単位で付与する
+permissions:
+  contents: read
+
+# 同時に複数のデプロイが走らないようにする
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 18
           cache: "yarn"
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Set Env
         run: |
-          echo "OWNER_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $1}')" >> $GITHUB_ENV
-          echo "REPO_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')" >> $GITHUB_ENV
-          echo "CURRENT_VERSION=$(node -p 'require("./lerna.json").version')" >> $GITHUB_ENV
+          echo "OWNER_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $1}')" >> "$GITHUB_ENV"
+          echo "REPO_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')" >> "$GITHUB_ENV"
+          echo "CURRENT_VERSION=$(node -p 'require("./lerna.json").version')" >> "$GITHUB_ENV"
       - name: Install
         run: yarn install
       - name: Build Packages
@@ -35,8 +44,22 @@ jobs:
           REPO_NAME: ${{ env.REPO_NAME }}
           CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
         working-directory: website/
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/dist
+          path: ./website/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    # GitHub Pages へのデプロイに必要な権限を deploy ジョブのみに付与する
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## 概要

`website` CI が `peaceiris/actions-gh-pages` による gh-pages ブランチへの push で 403 (`Permission to ... denied to github-actions[bot]`) となり失敗していた問題を修正する。

公式の `actions/upload-pages-artifact` + `actions/deploy-pages` による GitHub Pages デプロイへ移行し、gh-pages ブランチへの push 自体を不要にすることで 403 を根本的に解消する。

Closes #84

## 変更内容

- `peaceiris/actions-gh-pages` を `actions/configure-pages` / `actions/upload-pages-artifact` / `actions/deploy-pages` に置き換え
- ジョブを build / deploy に分割
- 権限を最小化（workflow 既定は `contents: read`、`pages: write` と `id-token: write` は deploy ジョブのみ）
- `concurrency` と `environment: github-pages` を追加

## マージ前に必要な手動設定（重要）

現在のリポジトリ設定は `build_type: legacy`（source = `gh-pages` ブランチ）になっている。公式 Actions デプロイを有効にするには、マージ前後に以下を変更する必要がある。これを行わないと deploy ジョブが失敗する。

Settings → Pages → Build and deployment → Source を **GitHub Actions** に変更

## 補足

- 元の `node-version: 18` は維持し、本 PR のスコープは 403 修正に限定した（node のバージョンアップは別途）

🤖 Generated with [Claude Code](https://claude.com/claude-code)