### PR TITLE
fix: bump website CI node to 24

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 18
+          node-version: 24
           cache: "yarn"
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0


### PR DESCRIPTION
## 概要

#121 で公式 GitHub Pages デプロイへ移行したが、`website` workflow の `Install`（yarn install）が node 18 では失敗していた。

```
error lerna@9.0.7: The engine "node" is incompatible with this module.
Expected version "^20.19.0 || ^22.12.0 || >=24.0.0". Got "18.20.8"
```

lerna@9 が node `>=20` を要求しているため、他の workflow（test.yml 等）と同じ node 24 に上げる。

## 変更内容

- `website.yml` の `node-version` を 18 → 24

## 補足

- #121 で node 18 維持としていたが、lerna@9 の engine 要件で install できないため修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)