### PR TITLE
feat: add rule to disallow spaces around slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ textlint --preset preset-ja-spacing README.md
 
 かっこの外側、内側ともにスペースを入れないようにするルール
 
+### [textlint-rule-ja-no-space-around-slash](packages/textlint-rule-ja-no-space-around-slash)
+
+スラッシュの前後にスペースを入れないようにするルール。
+
 ### [textlint-rule-ja-space-after-exclamation](packages/textlint-rule-ja-space-after-exclamation)
 
 文末に感嘆符を使用し、後に別の文が続く場合は、直後に全角スペースを挿入します。
@@ -100,6 +104,7 @@ textlint --preset preset-ja-spacing README.md
         "preset-ja-spacing": {
              "ja-nakaguro-or-halfwidth-space-between-katakana": true,
              "ja-no-space-around-parentheses": true,
+             "ja-no-space-around-slash": true,
              "ja-no-space-between-full-width": true,
              "ja-space-between-half-and-full-width": {
                  "space": "never"

--- a/packages/textlint-rule-ja-no-space-around-slash/LICENSE
+++ b/packages/textlint-rule-ja-no-space-around-slash/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/textlint-rule-ja-no-space-around-slash/README.md
+++ b/packages/textlint-rule-ja-no-space-around-slash/README.md
@@ -1,0 +1,69 @@
+# textlint-rule-ja-no-space-around-slash
+
+スラッシュ周りのスペースについてのtextlintルール
+
+スラッシュの前後にスペースを入れません。
+
+    OK: struct/enum
+    NG: struct / enum
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install textlint-rule-ja-no-space-around-slash
+
+## Usage
+
+Via `.textlintrc`(Recommended)
+
+```json
+{
+    "rules": {
+        "ja-no-space-around-slash": true
+    }
+}
+```
+
+Via CLI
+
+```
+textlint --rule ja-no-space-around-slash README.md
+```
+
+## Fixable
+
+[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+
+`textlint --fix`の自動修正に対応しています。
+
+## Changelog
+
+See [Releases page](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm i -d && npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/textlint-rule-ja-no-space-around-slash/package.json
+++ b/packages/textlint-rule-ja-no-space-around-slash/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "textlint-rule-preset-ja-spacing",
+  "name": "textlint-rule-ja-no-space-around-slash",
   "version": "3.0.0",
-  "description": "textlint-rule-preset-ja-spacingのルールプリセット",
+  "description": "スラッシュ周りのスペースについてのtextlintルール",
   "main": "lib/index.js",
   "files": [
     "src/",
@@ -32,16 +32,6 @@
     "textlint-scripts": "^13.3.3"
   },
   "dependencies": {
-    "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^3.0.0",
-    "textlint-rule-ja-no-space-around-parentheses": "^3.0.0",
-    "textlint-rule-ja-no-space-around-slash": "^3.0.0",
-    "textlint-rule-ja-no-space-between-full-width": "^3.0.0",
-    "textlint-rule-ja-space-after-exclamation": "^3.0.0",
-    "textlint-rule-ja-space-after-question": "^3.0.0",
-    "textlint-rule-ja-space-around-code": "^3.0.0",
-    "textlint-rule-ja-space-around-emphasis": "^3.0.0",
-    "textlint-rule-ja-space-around-link": "^3.0.0",
-    "textlint-rule-ja-space-around-strong": "^3.0.0",
-    "textlint-rule-ja-space-between-half-and-full-width": "^3.0.0"
+    "textlint-rule-helper": "^2.2.4"
   }
 }

--- a/packages/textlint-rule-ja-no-space-around-slash/src/index.js
+++ b/packages/textlint-rule-ja-no-space-around-slash/src/index.js
@@ -1,0 +1,41 @@
+// LICENSE : MIT
+"use strict";
+/*
+ * スラッシュの前後にスペースを入れません。
+ */
+import { RuleHelper } from "textlint-rule-helper";
+
+const MESSAGE = "スラッシュの前後にスペースを入れません。";
+
+function reporter(context) {
+    const { Syntax, RuleError, report, fixer, getSource } = context;
+    const helper = new RuleHelper();
+    return {
+        [Syntax.Str](node) {
+            if (!helper.isPlainStrNode(node)) {
+                return;
+            }
+            const text = getSource(node);
+            for (const match of text.matchAll(/[ 　]*\/[ 　]*/g)) {
+                const matchedText = match[0];
+                if (!/[ 　]/.test(matchedText)) {
+                    continue;
+                }
+                const startIndex = match.index;
+                const fixedText = matchedText.replace(/[ 　]*\/[ 　]*/, "/");
+                report(
+                    node,
+                    new RuleError(MESSAGE, {
+                        index: startIndex,
+                        fix: fixer.replaceTextRange([startIndex, startIndex + matchedText.length], fixedText)
+                    })
+                );
+            }
+        }
+    };
+}
+
+module.exports = {
+    linter: reporter,
+    fixer: reporter
+};

--- a/packages/textlint-rule-ja-no-space-around-slash/src/index.js
+++ b/packages/textlint-rule-ja-no-space-around-slash/src/index.js
@@ -6,6 +6,8 @@
 import { RuleHelper } from "textlint-rule-helper";
 
 const MESSAGE = "スラッシュの前後にスペースを入れません。";
+const slashWithSpaces = /[ 　]{0,10}\/[ 　]{0,10}/g;
+const slashWithSpacesForFix = /[ 　]{0,10}\/[ 　]{0,10}/;
 
 function reporter(context) {
     const { Syntax, RuleError, report, fixer, getSource } = context;
@@ -16,13 +18,13 @@ function reporter(context) {
                 return;
             }
             const text = getSource(node);
-            for (const match of text.matchAll(/[ 　]*\/[ 　]*/g)) {
+            for (const match of text.matchAll(slashWithSpaces)) {
                 const matchedText = match[0];
                 if (!/[ 　]/.test(matchedText)) {
                     continue;
                 }
                 const startIndex = match.index;
-                const fixedText = matchedText.replace(/[ 　]*\/[ 　]*/, "/");
+                const fixedText = matchedText.replace(slashWithSpacesForFix, "/");
                 report(
                     node,
                     new RuleError(MESSAGE, {

--- a/packages/textlint-rule-ja-no-space-around-slash/test/index-test.js
+++ b/packages/textlint-rule-ja-no-space-around-slash/test/index-test.js
@@ -68,6 +68,16 @@ tester.run("スラッシュ周りのスペース", rule, {
             ]
         },
         {
+            text: "struct          /          enum",
+            output: "struct/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
             text: "struct　/enum",
             output: "struct/enum",
             errors: [

--- a/packages/textlint-rule-ja-no-space-around-slash/test/index-test.js
+++ b/packages/textlint-rule-ja-no-space-around-slash/test/index-test.js
@@ -1,0 +1,174 @@
+// LICENSE : MIT
+"use strict";
+import TextLintTester from "textlint-tester";
+import rule from "../src/index";
+var tester = new TextLintTester();
+const MESSAGE = "スラッシュの前後にスペースを入れません。";
+tester.run("スラッシュ周りのスペース", rule, {
+    valid: [
+        "struct/enum",
+        "これはstruct/enumです。",
+        "HTTP/2",
+        "1/2",
+        "https://example.com/path",
+        "`struct / enum`",
+        "./path/to/file",
+        "[struct / enum](https://example.com)",
+        "[struct / enum][]" + "\n\n" + "[struct / enum]: https://example.com"
+    ],
+    invalid: [
+        {
+            text: "struct / enum",
+            output: "struct/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
+            text: "struct/ enum",
+            output: "struct/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
+            text: "struct /enum",
+            output: "struct/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
+            text: "struct　/　enum",
+            output: "struct/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
+            text: "struct  /  enum",
+            output: "struct/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
+            text: "struct　/enum",
+            output: "struct/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
+            text: "struct/　enum",
+            output: "struct/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
+            text: "これはstruct / enumです。",
+            output: "これはstruct/enumです。",
+            errors: [
+                {
+                    message: MESSAGE
+                }
+            ]
+        },
+        {
+            text: "日本語 / 日本語",
+            output: "日本語/日本語",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 4
+                }
+            ]
+        },
+        {
+            text: "struct / 日本語",
+            output: "struct/日本語",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 7
+                }
+            ]
+        },
+        {
+            text: "日本語 / enum",
+            output: "日本語/enum",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 4
+                }
+            ]
+        },
+        {
+            text: "（A / B）",
+            output: "（A/B）",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 3
+                }
+            ]
+        },
+        {
+            text: "A / B / C",
+            output: "A/B/C",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 2
+                },
+                {
+                    message: MESSAGE,
+                    column: 6
+                }
+            ]
+        },
+        {
+            text: "/ root",
+            output: "/root",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 1
+                }
+            ]
+        },
+        {
+            text: "root /",
+            output: "root/",
+            errors: [
+                {
+                    message: MESSAGE,
+                    column: 5
+                }
+            ]
+        }
+    ]
+});

--- a/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
+++ b/packages/textlint-rule-ja-space-between-half-and-full-width/test/index-test.js
@@ -9,6 +9,7 @@ tester.run("全角文字と半角文字の間", rule, {
         "JTF標準",
         "これも、OK。",
         "最新のversionは1.2.3です。",
+        "これはstruct / enumです。",
         {
             text: "JTF標準",
             options: {
@@ -42,6 +43,12 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             text: "最新の version は 1.2.3 です。",
             options: {
                 space: ["alphabets", "numbers"]
+            }
+        },
+        {
+            text: "これは struct / enum です。",
+            options: {
+                space: "always"
             }
         },
         // ignore
@@ -197,6 +204,18 @@ Pull Request、コミットのやりかたなどが書かれています。`,
             errors: [{ message: "原則として、全角文字と半角文字の間にスペースを入れません。" }]
         },
         {
+            text: "これは struct / enum です。",
+            output: "これはstruct / enumです。",
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れません。"
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れません。"
+                }
+            ]
+        },
+        {
             text: "aaa と bbb 、 ccc と ddd",
             output: "aaaとbbb 、 cccとddd",
             options: {
@@ -277,6 +296,21 @@ Pull Request、コミットのやりかたなどが書かれています。`,
                 {
                     message: "原則として、全角文字と半角文字の間にスペースを入れます。",
                     column: 3
+                }
+            ]
+        },
+        {
+            text: "これはstruct / enumです。",
+            output: "これは struct / enum です。",
+            options: {
+                space: "always"
+            },
+            errors: [
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。"
+                },
+                {
+                    message: "原則として、全角文字と半角文字の間にスペースを入れます。"
                 }
             ]
         },

--- a/packages/textlint-rule-preset-ja-spacing/src/index.js
+++ b/packages/textlint-rule-preset-ja-spacing/src/index.js
@@ -4,6 +4,7 @@ module.exports = {
     rules: {
         "ja-nakaguro-or-halfwidth-space-between-katakana": require("textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana"),
         "ja-no-space-around-parentheses": require("textlint-rule-ja-no-space-around-parentheses"),
+        "ja-no-space-around-slash": require("textlint-rule-ja-no-space-around-slash"),
         "ja-no-space-between-full-width": require("textlint-rule-ja-no-space-between-full-width"),
         "ja-space-between-half-and-full-width": require("textlint-rule-ja-space-between-half-and-full-width"),
         "ja-space-after-exclamation": require("textlint-rule-ja-space-after-exclamation"),
@@ -16,6 +17,7 @@ module.exports = {
     rulesConfig: {
         "ja-nakaguro-or-halfwidth-space-between-katakana": true,
         "ja-no-space-around-parentheses": true,
+        "ja-no-space-around-slash": true,
         "ja-no-space-between-full-width": true,
         "ja-space-between-half-and-full-width": {
             space: "never"


### PR DESCRIPTION
このPRでは、「struct / enum」のようなスラッシュの前後にスペースを入れる表現を検出するルールを追加します。

`ja-space-between-half-and-full-width`では、半角文字と全角文字の間のスペースについては検出できますが、半角文字のまとまりの内部にあるスペースについては検出できません。そのため、「struct / enum」や「A / B / C」のような表記は既存ルールでは修正対象にならず、日本語技術文書中の表記ゆれとして残る可能性があります。

追加したルールでは、文章中の「/」の前後にある半角・全角スペースを検出し、自動修正でスペースを除去できます。`textlint-rule-helper`の`isPlainStrNode()`が偽となるノードは校正対象から除外されます。

## 参考

### 日本語

- [JTF日本語標準スタイルガイド 第3.0版](https://www.jtf.jp/pdf/jtf_style_guide.pdf)
  - 3.2.3 スラッシュ（/）（／）
    - 1/3（分数）、I/O、50Hz/60Hz、オン／オフ
- [Red Hat 日本語スタイルガイド](https://developer.jboss.org/servlet/JiveServlet/previewBody/52925-102-2-171801/DOC-954596.pdf)
  - 5.3.3. スラッシュ ( / )
    - TCP/IP、I/O、登録/変更/削除
- [IT英語スタイルガイド](https://styleguide.progeigo.org/docs/punctuation-symbol/slashes/)
  - B. 句読点と記号 スラッシュ（/）
    - On/Off、TCP/IP、A/B Testing
 
### 英語

- [Microsoft Style Guide - Slashes](https://learn.microsoft.com/en-us/style-guide/punctuation/slashes)
  - client/server, TCP/IP, CD/DVD drive, on/off

なお、[Google developer documentation style guide](https://developers.google.com/style/slashes)と[Red Hat Technical Writing Style Guide](https://stylepedia.net/style/#slashes)は代替関係の表現に「/」を使うことを避ける方針です。