### PR TITLE
Fix PR comment job to skip on fork pull requests

### DIFF
--- a/.github/workflows/check-provenance.yml
+++ b/.github/workflows/check-provenance.yml
@@ -147,7 +147,11 @@ jobs:
     name: Post PR Comment
     runs-on: ubuntu-latest
     needs: check-provenance
-    if: (needs.check-provenance.outputs.has_missing == 'true' || needs.check-provenance.outputs.has_unpublished == 'true') && github.event_name == 'pull_request'
+    # Skip on fork PRs: the GITHUB_TOKEN is read-only for forks, so commenting would fail with 403.
+    if: >
+      (needs.check-provenance.outputs.has_missing == 'true' || needs.check-provenance.outputs.has_unpublished == 'true')
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to prevent the "Post PR Comment" job from attempting to comment on pull requests from forks, which would fail due to read-only token permissions.

## Key Changes
- Added a condition to check that the pull request originates from the same repository (`github.event.pull_request.head.repo.full_name == github.repository`)
- Reformatted the `if` condition for improved readability using YAML's multi-line syntax
- Added a clarifying comment explaining why fork PRs are skipped

## Implementation Details
The job now includes an additional check that ensures the PR's source repository matches the target repository. This prevents the workflow from attempting to post comments on fork PRs, which would fail with a 403 error since the `GITHUB_TOKEN` is read-only for forked repositories. The condition maintains the existing logic for checking provenance issues while adding this safety check.

https://claude.ai/code/session_01XjG5eSLKvQh55C57DHiESu